### PR TITLE
Fix: sensors units read from server data

### DIFF
--- a/src/app/components/kit/showKit/showKit.controller.js
+++ b/src/app/components/kit/showKit/showKit.controller.js
@@ -65,7 +65,7 @@
       // ugly but prevents undesired api calls.
       // newVal might be empty obj so
       // if(newVal) won't be enough here
-      if ((Object.getOwnPropertyNames(newVal).length === 0) &&
+      if (newVal && (Object.getOwnPropertyNames(newVal).length === 0) &&
         (typeof(newVal) !== 'number')){
         return;
       }

--- a/src/app/core/api/measurement.service.js
+++ b/src/app/core/api/measurement.service.js
@@ -1,0 +1,30 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .factory('measurement', measurement);
+
+  measurement.$inject = ['Restangular'];
+
+  function measurement(Restangular) {
+
+    var service = {
+      getTypes: getTypes,
+      getMeasurement: getMeasurement
+
+    };
+    return service;
+
+    ////////////////
+
+
+    function getTypes() {
+      return Restangular.all('measurements').getList();
+    }
+
+    function getMeasurement(mesID) {
+
+      return Restangular.one('measurements', mesID).get();
+    }
+  }
+})();

--- a/src/app/core/constructors/kit/fullKit.constructor.js
+++ b/src/app/core/constructors/kit/fullKit.constructor.js
@@ -61,7 +61,7 @@
           .value();
           
           return sensors.reduce(function(acc, sensor, index, arr) {
-            if(sensor.name === 'BATTERY') {
+            if(sensor.name === 'battery') {
               arr.splice(index, 1);
               
               if(options.type === 'main') {

--- a/src/app/core/constructors/sensor/sensor.constructor.js
+++ b/src/app/core/constructors/sensor/sensor.constructor.js
@@ -2,7 +2,15 @@
   'use strict';
 
   angular.module('app.components')
-    .factory('Sensor', ['sensorUtils', function(sensorUtils) {
+    .factory('Sensor', ['sensorUtils', 'measurement', function(sensorUtils,
+      measurement) {
+
+      /*jshint camelcase: false */
+      var measurementTypes;
+      measurement.getTypes()
+        .then(function(res) {
+          measurementTypes = res;
+        });
 
       /**
        * Sensor constructor
@@ -20,8 +28,13 @@
        * @property {string} previewDescription - Short Description for dashboard. Max 140 chars
        */
       function Sensor(sensorData, sensorTypes) {
-        this.name = sensorUtils.getSensorName(sensorData);
+
         this.id = sensorData.id;
+
+        this.name = _.result(_.find(measurementTypes, {
+          'id': sensorData.measurement_id
+        }), 'name');
+
         this.unit = sensorData.unit;
         this.value = sensorUtils.getSensorValue(sensorData);
         this.prevValue = sensorUtils.getSensorPrevValue(sensorData);
@@ -29,11 +42,13 @@
         this.arrow = sensorUtils.getSensorArrow(this.value, this.prevValue);
         this.color = sensorUtils.getSensorColor(this.name);
 
-        var description = sensorUtils.getSensorDescription(this.id, sensorTypes);
+        var description = sensorUtils.getSensorDescription(this.id,
+          sensorTypes);
         this.fullDescription = description;
-        this.previewDescription = description.length > 140 ? description.slice(0, 140).concat(' ... ') : description;
+        this.previewDescription = description.length > 140 ? description.slice(
+          0, 140).concat(' ... ') : description;
       }
 
-      return Sensor; 
+      return Sensor;
     }]);
 })();

--- a/src/app/core/utils/sensorUtils.service.js
+++ b/src/app/core/utils/sensorUtils.service.js
@@ -35,26 +35,32 @@
         return rollup;
       }
 
-      function getSensorName(sensor) {
-        var name = sensor.name;
-        var description = sensor.description;
+      function getSensorName(name) {
+
         var sensorName;
 
-        if( new RegExp('custom circuit', 'i').test(description) ) {
+        if( new RegExp('custom circuit', 'i').test(name) ) {
           sensorName = name;
         } else {
-          if(new RegExp('noise', 'i').test(description) ) {
+          if(new RegExp('noise', 'i').test(name) ) {
             sensorName = 'SOUND';
-          } else if(new RegExp('light', 'i').test(description) ) {
+          } else if(new RegExp('light', 'i').test(name) ) {
             sensorName = 'LIGHT';
-          } else if(new RegExp('wifi', 'i').test(description) ) {  
+          } else if((new RegExp('nets', 'i').test(name) ) || 
+              (new RegExp('wifi', 'i').test(name))) {  
             sensorName = 'NETWORKS';
-          } else if(new RegExp('co', 'i').test(description) ) {
+          } else if(new RegExp('co', 'i').test(name) ) {
             sensorName = 'CO';
-          } else if(new RegExp('no2', 'i').test(description) ) {
+          } else if(new RegExp('no2', 'i').test(name) ) {
             sensorName = 'NO2';
+          } else if(new RegExp('humidity', 'i').test(name) ) {
+            sensorName = 'HUMIDITY';
+          } else if(new RegExp('temperature', 'i').test(name) ) {
+            sensorName = 'TEMPERATURE';
+          } else if(new RegExp('panel', 'i').test(name) ) {
+            sensorName = 'SOLAR PANEL';
           } else {
-            sensorName = description;
+            sensorName = name;
           }          
         }
         return sensorName.toUpperCase();
@@ -117,7 +123,9 @@
 
       function getSensorIcon(sensorName) {
 
-        switch(sensorName) {
+        var thisName = getSensorName(sensorName);
+
+        switch(thisName) {
           case 'TEMPERATURE':
             return './assets/images/temperature_icon.svg';            
             
@@ -164,7 +172,7 @@
       }
 
       function getSensorColor(sensorName) {
-        switch(sensorName) {
+        switch(getSensorName(sensorName)) {
           case 'TEMPERATURE':
             return '#ffc107';            
             


### PR DESCRIPTION
Closes #131 
- [x]  read sensor units from api data
- [x]  read sensors name from api data

@pral2a 
description in the api data are too long
ex.: Electret microphone with envelope follower sound pressure sensor (noise)

and names are not human-readable
ex.: POM-3044P-R

if it is acceptable we can keep using fixtures for names. If not we would need to have the api return a slight different naming property
