### PR TITLE
Fix Firefox modal appearing off-screen

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -15,6 +15,13 @@
   body .kit_detailed .kit_chart .container .kit_chart_left .sensor_data {
     margin: 5% 0 4% 0;
   }
+
+  // This fixes Firefox modal offscreen issue.
+  // But does it break something else??
+  .md-dialog-container {
+    position: fixed;
+  }
+
 /*   section.map {
     z-index: 0;
   } */


### PR DESCRIPTION
This CSS change might break something else, I am not a fan of messing with 'default' CSS but here goes.

Might fix #232 ?

**Click 'Get your kit'**
![2017-02-02_1188x459](https://cloud.githubusercontent.com/assets/1689020/22570909/b79b67ee-e99d-11e6-9650-7c5e10bcdeb2.png)

**And modal should appear normally in Firefox**
![2017-02-02_1278x469](https://cloud.githubusercontent.com/assets/1689020/22570908/b7856d4a-e99d-11e6-980d-e11bfbc8341f.png)
