### PR TITLE
WIP: Footer is flowing underneath the top menu

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -2976,7 +2976,7 @@ md-content.md-default-theme, md-content {
   position: absolute;
   z-index: 1;
   width: 100%;
-  height: 64px;
+  //height: 64px;
   background-color: $background_blue_dark_background;
 }
 


### PR DESCRIPTION
The footer used to go underneath the top menu.

This does not work anymore, since the footer now has more height than 64 px.

So currently, the footer is overflowing