### PR TITLE
WIP: Add EU flags at the bottom

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -2977,6 +2977,7 @@ md-content.md-default-theme, md-content {
   z-index: 1;
   width: 100%;
   //height: 64px;
+
   background-color: $background_blue_dark_background;
 }
 


### PR DESCRIPTION
The footer used to go **underneath** the top menu.

This does **not** work anymore, since the footer now has more height than 64 px.

So currently, the footer is overflowing. We need to fix this **before** merging!

**Extra problem**
We already deployed this bug in production, reverted 2 commits to restore the master branch to normal.
**Solution**
We might need to 'revert' the commit on master, which reverted those changes. *Reverting a revert*