### PR TITLE
Make elements visible and get rid of "style" attributes

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -44,3 +44,5 @@ $large_priority: 10;
 $more_priority: 5;
 $medium_priority: 2;
 $small_priority: -1;
+
+$dropdown_blue: #3f51b5;

--- a/src/app/components/kit/editKit/editKit.html
+++ b/src/app/components/kit/editKit/editKit.html
@@ -50,7 +50,7 @@
                  <div class="" layout="row" layout-align="start center">
                    <label class="mr-10">Exposure:</label>
                    <md-select ng-model="vm.kitForm.exposure" placeholder="Select exposure">
-                     <md-option ng-repeat="exposure in vm.exposure" ng-value="{{ exposure.value }}">{{ exposure.name }}</md-option>
+                     <md-option class="color-dropdown" ng-repeat="exposure in vm.exposure" ng-value="{{ exposure.value }}">{{ exposure.name }}</md-option>
                    </md-select>
                  </div>
                </div>
@@ -120,7 +120,7 @@
                          class="kit_tags-header-searchbox md-text">
                 </md-select-header>
                 <md-optgroup label="tags">
-                  <md-option ng-selected="vm.kitForm.tags.includes(item.name)" ng-model="vm.kitForm.tags" ng-value="item" ng-repeat="item in vm.tags | filter:searchTerm">
+                  <md-option class="color-dropdown" ng-selected="vm.kitForm.tags.includes(item.name)" ng-model="vm.kitForm.tags" ng-value="item" ng-repeat="item in vm.tags | filter:searchTerm">
                     {{item.name}}
                   </md-option>
                 </md-optgroup>
@@ -147,7 +147,7 @@
         </section>
       </form>
       <div class="mt-50" layout="row" layout-align="center start" layout-margin layout-padding>
-        <md-button class="md-raised md-primary" ng-click="vm.submitFormAndKit()">Save</md-button>
+        <md-button flex class="md-raised md-accent" ng-click="vm.submitFormAndKit()">Save</md-button>
       </div>
       <div layout layout-padding layout-margin>
         <md-button flex ng-show="vm.setupAvailable" class="md-raised md-primary mb-30" ng-click="vm.submitFormAndNext()">Open kit set up</md-button>
@@ -174,7 +174,7 @@
           <div layout="row" layout-xs="column" layout-align="start start" layout-padding>
             <div flex-gt-xs="50">
               <h2>Mac address</h2>
-              <small>The setup tool will read the Mac Address automatically from your kit. Plase wait or enter it manually.</small>
+              <small>The setup tool will read the Mac Address automatically from your kit. Please wait or enter it manually.</small>
             </div>
             <div>
               <md-input-container>
@@ -186,7 +186,7 @@
         </section>
       </form>
       <div layout>
-        <md-button flex class="md-primary md-raised mb-30" ng-click="vm.submitFormAndKit()" ng-show="vm.nextAction == 'save'">Save</md-button>
+        <md-button flex class="md-accent md-raised mb-30" ng-click="vm.submitFormAndKit()" ng-show="vm.nextAction == 'save'">Save</md-button>
       </div>
       <md-progress-linear class="md-hue-3" ng-show="vm.nextAction == 'waiting'" md-mode="indeterminate"></md-progress-linear>  
       <md-button ng-disabled="true" ng-show="vm.nextAction == 'waiting'" class="md-primary timeline_button timeline_buttonOpen">Waiting for your kit's data<small>We are waiting for your kit to connect on-line, this can take a few minutes</small><small> Check the process on the report window and contact <a ng-href="mailto:support@smartcitizen.me">support@smartcitizen.me</a> if you have any problem.</small></md-button>

--- a/src/app/components/kit/newKit/newKit.html
+++ b/src/app/components/kit/newKit/newKit.html
@@ -41,7 +41,7 @@
               <div class="form_blockInput_select" layout="row" layout-align="start center">
                 <label>Exposure:</label>
                 <md-select ng-model="vm.kitForm.exposure" placeholder="Select exposure">
-                  <md-option ng-repeat="exposure in vm.exposure" ng-value="{{ exposure.value }}">{{ exposure.name }}</md-option>
+                  <md-option class="color-dropdown" ng-repeat="exposure in vm.exposure" ng-value="{{ exposure.value }}">{{ exposure.name }}</md-option>
                 </md-select>
               </div>
             </div>
@@ -55,7 +55,7 @@
           </div>
           <div class="mt-50"  flex-gt-xs="50">
             <div layout="row" layout-align="center center" class="" ng-if="!vm.kitForm.location.lat && !vm.kitForm.location.lng">
-              <md-button class="md-raised md-primary" ng-click="vm.getLocation()">Get your location</md-button>
+              <md-button class="md-raised md-accent" ng-click="vm.getLocation()">Get your location</md-button>
             </div>
             <div class="form_blockInput_map" ng-if="vm.kitForm.location.lat && vm.kitForm.location.lng">
               <leaflet center="vm.kitForm.location" defaults="vm.defaults" markers="vm.markers" tiles="vm.tiles" width="100%" height="100%"></leaflet>
@@ -99,7 +99,7 @@
 
       </form>
       <div layout>
-        <md-button flex class="md-raised md-primary" ng-click="vm.submitStepOne()">Next</md-button>
+        <md-button flex class="md-raised md-accent" ng-click="vm.submitStepOne()">Next</md-button>
       </div>
     </section>
   </section>

--- a/src/app/components/kit/showKit/showKit.html
+++ b/src/app/components/kit/showKit/showKit.html
@@ -120,7 +120,7 @@
               <md-select placeholder="CHOOSE SENSOR" ng-model="vm.selectedSensor">
                 <md-option ng-repeat="sensor in vm.chartSensors" ng-value="{{sensor.id}}" ng-selected="$first"
                   analytics-on="click" analytics-category="Kit Chart"
-                  analytics-event="click" analytics-label="Metric" style="color:#3f51b5">
+                  analytics-event="click" analytics-label="Metric" class="color-dropdown">
                   <md-icon md-svg-src="{{ sensor.icon }}"></md-icon>
                   <span class="md-primary">{{ sensor.name }}</span>
                 </md-option>
@@ -140,7 +140,7 @@
                 <md-select placeholder="NONE" ng-model="vm.selectedSensorToCompare">
                   <md-option ng-repeat="sensor in vm.sensorsToCompare" ng-value="{{sensor.id}}"
                     analytics-on="click" analytics-category="Kit Chart"
-                    analytics-event="click" analytics-label="Compare" style="color:#3f51b5">
+                    analytics-event="click" analytics-label="Compare" class="color-dropdown">
                     <md-icon md-svg-src="{{ sensor.icon }}"></md-icon>
                     <span class="md-primary">{{ sensor.name }}</span>
                   </md-option>
@@ -269,7 +269,7 @@
               <h4 class="ml-20">Other kits owned by {{ vm.kit.owner.username }}</h4>
               <kit-list kits="vm.sampleKits"></kit-list>
               <div layout="row" layout-align="end end">
-                <md-button class="md-primary md-raised" ng-href="/users/{{ vm.kit.owner.id }}" style="margin-right:23px" ng-if="vm.kit.owner.kits.length > 5" aria-label="">VIEW ALL KITS BY {{ vm.kit.owner.username }}</md-button>
+                <md-button class="btn-blue" ng-href="/users/{{ vm.kit.owner.id }}" style="margin-right:23px" ng-if="vm.kit.owner.kits.length > 5" aria-label="">VIEW ALL KITS BY {{ vm.kit.owner.username }}</md-button>
               </div>
             </section>
           </div>

--- a/src/app/components/kit/showKit/showKit.scss
+++ b/src/app/components/kit/showKit/showKit.scss
@@ -354,7 +354,7 @@ section .kit_menu {
 
     .hint{
       background-color: $off_black;
-      opacity: 0.8;
+      opacity: 0.6;
     }
 
     .container {

--- a/src/app/components/layout/layout.html
+++ b/src/app/components/layout/layout.html
@@ -3,7 +3,7 @@
 
     <a ui-sref="landing" class="logo_link">
       <md-tooltip md-direction="bottom">Visit the frontpage</md-tooltip>
-      <md-icon class="m-10 logo_icon" style="fill:white;" md-svg-src="./assets/images/LogotipoSmartCitizen.svg" alt="Insert Drive Icon">
+      <md-icon class="m-10 logo_icon" md-svg-src="./assets/images/LogotipoSmartCitizen.svg" alt="Insert Drive Icon">
       </md-icon>
     </a>
 
@@ -11,13 +11,13 @@
       <md-button hide-xs ng-show="vm.isShown" ui-sref="layout.home.kit({ id: ''})" class="md-flat map">
         <md-tooltip md-direction="bottom">Visit the map</md-tooltip>
         <md-icon md-svg-src="./assets/images/map_icon.svg" class="nav_icon"> </md-icon>
-        <span style="color:white;">Map</span>
+        <span>Map</span>
       </md-button>
 
       <md-menu hide show-gt-sm ng-show="vm.isShown" >
         <md-button ng-click="$mdMenu.open($event)">
           <md-icon md-svg-src="./assets/images/community_icon.svg" class="nav_icon"> </md-icon>
-        <span style="color:white;">Community</span>
+        <span>Community</span>
         </md-button>
 
         <md-menu-content ng-mouseleave="$mdMenu.close()">
@@ -35,8 +35,8 @@
 
     <section hide-xs layout="row" layout-align="{{vm.navRightLayout}}">
 
-      <div ng-show="vm.isShown" hide-xs hide-sm store logged="vm.isLoggedin" class="md-flat get" style="color:white;"></div>
-      <div ng-show="vm.isShown && !vm.isLoggedin" hide-xs login class="navbar_login_button " style="color:white;"></div>
+      <div ng-show="vm.isShown" hide-xs hide-sm store logged="vm.isLoggedin" class="md-flat get" class="color-white"></div>
+      <div ng-show="vm.isShown && !vm.isLoggedin" hide-xs login class="navbar_login_button " class="color-white"></div>
       <div ng-show="vm.isShown && !vm.isLoggedin" hide-xs signup class="navbar_signup_button"></div>
 
       <md-menu ng-show="vm.isShown && vm.isLoggedin" >
@@ -66,7 +66,7 @@
 <section layout="row" flex>
   <md-sidenav class="md-sidenav-right" md-component-id="right" md-whiteframe="3">
 
-    <md-toolbar style="background-color:black" layout="row" layout-align="end center">
+    <md-toolbar layout="row" layout-align="end center">
       <md-button ng-click="toggleRight()" layout="column" layout-align="center center"> 
         <img class="" ng-src="{{'./assets/images/menu2.svg' }}" />
       </md-button>

--- a/src/app/components/login/loginModal.html
+++ b/src/app/components/login/loginModal.html
@@ -1,7 +1,7 @@
 <md-dialog>
   <md-toolbar>
     <div class="md-toolbar-tools">
-      <h2 style="color: white">Log in</h2>
+      <h2>Log in</h2>
       <span flex></span>
       <md-button class="md-icon-button" ng-click="cancel()">
         <md-icon md-svg-icon="./assets/images/close_icon_blue.svg" aria-label="Close dialog"></md-icon>

--- a/src/app/components/map/mapTagModal.html
+++ b/src/app/components/map/mapTagModal.html
@@ -24,7 +24,7 @@
       </md-content>
 
     </div>
-    <md-button style="font-size:18px" class="md-warn btn-full" ng-click="vm.clear()">Clear selection</md-button>
+    <md-button class="md-warn btn-full" ng-click="vm.clear()">Clear selection</md-button>
     <md-button class="btn-blue btn-full" ng-click="vm.answer()">Apply</md-button>
   </md-dialog-content>
 </md-dialog>

--- a/src/app/components/myProfile/Users.html
+++ b/src/app/components/myProfile/Users.html
@@ -3,7 +3,7 @@
     <div style="max-width:500px">
       <div class="myProfile_form_avatar" layout="row" layout-align="start center">
         <img ng-src="{{ vm.user.profile_picture || vm.user.avatar || './assets/images/avatar.svg' }}" class="myProfile_form_avatarImage" />
-        <md-button class="md-raised md-primary" ngf-select ngf-change="vm.uploadAvatar($files)">CHANGE AVATAR</md-button>
+        <md-button class="md-raised md-accent" ngf-select ngf-change="vm.uploadAvatar($files)">CHANGE AVATAR</md-button>
       </div>
 
       <form ng-submit="vm.updateUser(vm.formUser)">
@@ -79,7 +79,7 @@
           </span>
           </p>
         </div>
-        <md-button type="submit" class="md-primary md-raised" type="submit">UPDATE PROFILE</md-button> <!-- ng-click="vm.updateUser(vm.formUser)" -->
+        <md-button type="submit" class="md-accent md-raised" type="submit">UPDATE PROFILE</md-button> <!-- ng-click="vm.updateUser(vm.formUser)" -->
       </form>
 
       <div class="mb-20">
@@ -100,7 +100,7 @@
         <small>This API Key is limited to the <a target="_blank" href="http://developer.smartcitizen.me/#legacy">legacy API</a>.</small>
       </div>
 
-      <md-button class="md-raised md-warn" ng-click="vm.removeUser()" style="font-size:18px" type="button">DELETE ACCOUNT</md-button>
+      <md-button class="md-raised md-warn" ng-click="vm.removeUser()" type="button">DELETE ACCOUNT</md-button>
       <br />
       <small>Delete your profile will erase ALL your data. Please think twice before clicking this button.</small>
     </div>

--- a/src/app/components/static/styleguide.html
+++ b/src/app/components/static/styleguide.html
@@ -161,7 +161,6 @@
           <md-button>empty button (no class)</md-button>
           <h4>Custom</h4>
           <md-button class="btn-round btn-cyan">btn-round btn-cyan</md-button>
-          <md-icon style="color:#F43D4D" md-font-icon="fa fa-wifi"></md-icon><span class="kitList_state kitList_state_not_configured state">not configured</span></span>
         </div>
       </div>
 

--- a/src/app/helpers.scss
+++ b/src/app/helpers.scss
@@ -8,6 +8,9 @@
 .color-white{
   color: white !important;
 }
+.color-dropdown{
+  color: $dropdown_blue !important;
+}
 .color-black{
   color: $off_black;
 }
@@ -62,6 +65,9 @@
 // Background helpers
 .bg-white{
   background-color: #fff;
+}
+.bg-black{
+  background-color: black;
 }
 .bg-green{
   background-color: $green;
@@ -174,6 +180,7 @@
   width: 100%;
   border-radius: 0px;
   margin: 0px;
+  padding:12px 29px;
 }
 
 .btn-small {

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -181,12 +181,12 @@ section.info{
 }
 
 a{
-  color: $secondary_color;
+  color: $blue;
   text-decoration: none;
 
   &:hover, &:active{
     text-decoration: none;
-    color: $grey;
+    color: $grey_darker;
   }
 }
 a.md-button, a,
@@ -202,6 +202,10 @@ button.md-button, button{
 md-toolbar{
   background-color: $background_blue_dark_navbar !important;
   z-index: $large_priority;
+  color: white !important;
+  md-icon{
+    fill: white !important;
+  }
   //height: 64px;
 }
 
@@ -1655,7 +1659,7 @@ button.doorbell-button {
 }
 .timeline_line {
   width: 500px;
-  border: 1px solid $blue;
+  border: 1px solid $yellow;
   position: relative;
   top: 14px;
 }
@@ -1672,18 +1676,17 @@ button.doorbell-button {
   color: white;
   font-weight: bold;
   &.is-on {
-    border: 2px solid $blue;
-    background-color: $blue;
+    border: 2px solid $yellow;
+    background-color: $yellow;
   }
   &.is-off {
-    background-color: none;
-    border: 2px solid $blue;
-    color: $blue;
+    border: 2px solid $yellow;
+    color: $yellow;
   }
 }
 .timeline_stepName {
   text-transform: uppercase;
-  color: $terciary_color;
+  color: $yellow;
   font-size:18px;
 
   &.vertical {


### PR DESCRIPTION
Hi @viktorsmari 

This pull request closes issue #398 
<img width="1386" alt="Screen Shot 2019-07-23 at 4 00 11 PM" src="https://user-images.githubusercontent.com/43182178/61718468-5e7b0980-ad63-11e9-91ef-58fac061439e.png">

I also get rid of some unnecessary "style" attributes for colors and font sizes (and clicked around the page to make sure it's OK). So now all popup will have white headlines and icons.

<img width="545" alt="Screen Shot 2019-07-23 at 3 59 40 PM" src="https://user-images.githubusercontent.com/43182178/61718464-5ae78280-ad63-11e9-92cf-ff0bb4999359.png">

Thanks