### PR TITLE
Remove angulartics.google.analytics

### DIFF
--- a/src/app/app.module.js
+++ b/src/app/app.module.js
@@ -14,7 +14,6 @@ angular.module('app', [
   'papa-promise',
   'angularLoad',
   'angulartics',
-  'angulartics.google.analytics',
   'ngSanitize',
   'angular-clipboard',
   'ngCookies',


### PR DESCRIPTION
**NOTE** this appears **not** to be a problem in production.

When starting the project on `localhost:8080` on Firefox, Linux - we get a blank white screen.

Errors in the console say the following module is not working, and needs to be removed.
`'angulartics.google.analytics'`


When removing it from the `app.module.js` file, it starts working normally again.

```
Uncaught Error: [$injector:modulerr] Failed to instantiate module app due to:
[$injector:modulerr] Failed to instantiate module angulartics.google.analytics due to:
[$injector:nomod] Module 'angulartics.google.analytics' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.
```

@pral2a do you know this module? It was added in 2015 by Arel, and there is already another module named the same in the file.

Sources:
- https://github.com/angulartics/angulartics
- https://github.com/angulartics/angulartics-google-analytics