### PR TITLE
Don't error if storing markers in localstorage throws an error

### DIFF
--- a/src/app/core/api/device.service.js
+++ b/src/app/core/api/device.service.js
@@ -99,8 +99,11 @@
           timestamp: new Date(),
           data: data
         };
-
-        $window.localStorage.setItem('smartcitizen.markers', JSON.stringify(obj) );
+        try {
+          $window.localStorage.setItem('smartcitizen.markers', JSON.stringify(obj) );
+        } catch {
+          console.log("Could not store markers in localstorage. skipping...");
+        }
         worldMarkers = obj.data;
       }
 


### PR DESCRIPTION
The bug on some versions of safari was caused by this - for reasons unknown it was throwing a quota exceeded error when we go to cache the markers. The app appears to work without this in any case, so we just catch the error and log an informational message before carrying on, which fixes the safari issue.