### PR TITLE
Kit cards on user page use information from /user

### DIFF
--- a/src/app/components/userProfile/userProfile.controller.js
+++ b/src/app/components/userProfile/userProfile.controller.js
@@ -42,9 +42,9 @@
             }
 
             device.createKitBlueprints().then(function(){
-              vm.kits = vm.user.kits.map(function(data){
+              $q.all(vm.kits = vm.user.kits.map(function(data){
                 return new PreviewKit(data);
-              })
+              }))
             })
 
           }).then(function(error) {


### PR DESCRIPTION
This PR fixes https://github.com/fablabbcn/smartcitizen-web/issues/447 by using data from the `/users` endpoint to populate the cards in the `/users` page.