### PR TITLE
Fix gulp-cli version to 2.3.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Test something (currently we have no tests)
       run: |
-        npm install -g gulp-cli
+        npm install -g gulp-cli@2.3.0
         export NODE_OPTIONS=--use-openssl-ca
         npm install
         gulp build


### PR DESCRIPTION
Fixes issues with build after  `gulp-cli` update on `npm`.