### PR TITLE
Bugfix/content margins

### DIFF
--- a/src/app/components/static/about.html
+++ b/src/app/components/static/about.html
@@ -5,7 +5,7 @@
     </div>
   </div>
   <div class="">
-    <div class="content">
+    <div class="content" style="margin-top: 150px">
       <h2 id="who">Who</h2>
       <p>
         The project is born within <a href="http://fablabbcn.org" class="about">Fab Lab Barcelona</a> at the <a href="http://www.iaac.net" class="about">Institute for Advanced Architecture of Catalonia</a>, both focused centers on the impact of new technologies at different scales of human habitat, from the bits to geography.

--- a/src/app/components/static/policy.html
+++ b/src/app/components/static/policy.html
@@ -6,7 +6,7 @@
   </div>
 
 <div class="">
-<div class="content">
+<div class="content" style="margin-top: 150px">
   <h2>Content</h2>
   <ul id="policy-toc">
   <li class="policy-toc" id="header"><a href="#terms-of-use">Terms of use</a></li>


### PR DESCRIPTION
Minor fix on /about and /policy pages to avoid content to be behind the top banner. A bit dirty workaround, but not too important so that we can't do this..