### PR TITLE
Enhancement/checkboxes policy

### DIFF
--- a/src/app/components/kit/editKit/editKit.controller.js
+++ b/src/app/components/kit/editKit/editKit.controller.js
@@ -109,6 +109,8 @@
                 zoom: 16
               },
               is_private: vm.device.isPrivate,
+              precise_location: vm.device.preciseLocation,
+              enable_forwarding: vm.device.enableForwarding,
               notify_low_battery: vm.device.notifications.lowBattery,
               notify_stopped_publishing: vm.device.notifications.stopPublishing,
               tags: vm.device.userTags,
@@ -165,6 +167,8 @@
           latitude: vm.deviceForm.location.lat,
           longitude: vm.deviceForm.location.lng,
           is_private: vm.deviceForm.is_private,
+          enable_forwarding: vm.deviceForm.enable_forwarding,
+          precise_location: vm.deviceForm.precise_location,
           notify_low_battery: vm.deviceForm.notify_low_battery,
           notify_stopped_publishing: vm.deviceForm.notify_stopped_publishing,
           mac_address: "",

--- a/src/app/components/kit/editKit/editKit.html
+++ b/src/app/components/kit/editKit/editKit.html
@@ -142,12 +142,13 @@
             </div>
           </div>
         </section> -->
+        <!-- TODO - Only for admins and researchers now, but should be private for anyone, same for precise location -->
         <section class="bg-white relaxed-layout" layout="row" layout-xs="column" layout-align="space-around start" layout-padding ng-if="vm.userRole === 'researcher' || vm.userRole === 'admin'">
           <div flex-gt-xs="50">
             <div layout="row">
               <div class="">
                 <h2>Open data</h2>
-                <small>Sometimes, your devices might be collecting sensitive personal data (i.e. your exact location or by GPS using in your bike).<br>Check the box in case you want to prevent others from accesssing your data.
+                <small>Sometimes, your devices might be collecting sensitive personal data (i.e. your exact location or by GPS using in your bike).<br>Check the box in case you want to prevent others from accesssing your data. You can also choose to blurr the location, or enable MQTT forwarding.
                 </small>
               </div>
             </div>
@@ -158,6 +159,12 @@
                <md-checkbox ng-model="vm.deviceForm.is_private">
                  <label>Make this device private</label>
                </md-checkbox>
+               <md-checkbox ng-model="vm.deviceForm.precise_location">
+                <label>Enable precise location</label>
+              </md-checkbox>
+              <md-checkbox ng-model="vm.deviceForm.enable_forwarding">
+                <label>Enable MQTT forwarding</label>
+              </md-checkbox>
             </div>
           </div>
         </section>

--- a/src/app/components/kit/editKit/editKit.html
+++ b/src/app/components/kit/editKit/editKit.html
@@ -36,7 +36,7 @@
       </div>
       <!-- TODO: Cosmetic Make nicer -->
       <!-- <md-button style="margin-left: auto" class="md-flat md-primary timeline_buttonBack" ng-click="vm.backToDevice()">Back to Device</md-button> -->
-      <md-button ng-show="vm.step===1" class="timeline_buttonBack btn-round-new btn-outline-white" ng-click="vm.backToProfile()">Back<span class="timeline-btn-extra"> to Profile</span></md-button>
+      <md-button ng-show="vm.step===1" class="timeline_buttonBack btn-round-new btn-outline-white" ng-click="vm.backToProfile()">Back</md-button>
       <md-button class="btn-round-new btn-outline-white-blue" ng-click="vm.submitFormAndKit()">Save</md-button>
     </div>
   </section>

--- a/src/app/core/constructors/device/device.constructor.js
+++ b/src/app/core/constructors/device/device.constructor.js
@@ -40,6 +40,8 @@
         this.systemTags = deviceUtils.parseSystemTags(object);
         this.userTags = deviceUtils.parseUserTags(object);
         this.isPrivate = deviceUtils.isPrivate(object);
+        this.preciseLocation = deviceUtils.preciseLocation(object);
+        this.enableForwarding = deviceUtils.enableForwarding(object);
         this.notifications = deviceUtils.parseNotifications(object);
         this.lastReadingAt = timeUtils.parseDate(object.last_reading_at);
         this.createdAt = timeUtils.parseDate(object.created_at);

--- a/src/app/core/utils/deviceUtils.service.js
+++ b/src/app/core/utils/deviceUtils.service.js
@@ -20,6 +20,8 @@
         parseHardwareInfo: parseHardwareInfo,
         parseHardwareName: parseHardwareName,
         isPrivate: isPrivate,
+        preciseLocation: preciseLocation,
+        enableForwarding: enableForwarding,
         isLegacyVersion: isLegacyVersion,
         isSCKHardware: isSCKHardware,
         parseState: parseState,
@@ -167,7 +169,15 @@
       }
 
       function isPrivate(object) {
-        return object.is_private;
+        return object.data_policy.is_private;
+      }
+
+      function preciseLocation(object) {
+        return object.data_policy.precise_location;
+      }
+
+      function enableForwarding(object) {
+        return object.data_policy.enable_forwarding	;
       }
 
       function isLegacyVersion (object) {


### PR DESCRIPTION
Adds check-boxes on kit-edit page for users to be able to enable data forwarding directly. 
Fixes a minor issue after latest update on API devices endpoint where the "is_private" property was moved into "data policy".