### PR TITLE
Connect to monolith and sort out user auth spagetti

### DIFF
--- a/src/app/app.config.js
+++ b/src/app/app.config.js
@@ -25,22 +25,24 @@
           animation.mapStateLoading();
         }
 
-        if(trans.to().authenticate === false) {
-          if(auth.isAuth()) {
-            console.log('-- already logged in users cannot go to /login or /signup');
-            // TODO: Bug
-            // does not redirect because e is undefined
-            //e.preventDefault();
-            //$state.go('layout.home.kit');
-            return;
-          }
-        }
+        // if(trans.to().authenticate === false) {
+        //   if(auth.isAuth()) {
+        //     console.log('-- already logged in users cannot go to /login or /signup');
+        //     console.log('layout.home.kit')
+        //     // TODO: Bug
+        //     // does not redirect because e is undefined
+        //     //e.preventDefault();
+        //     //$state.go('layout.home.kit');
+        //     return;
+        //   }
+        // }
 
-        if(trans.to().authenticate) {
-          if(!auth.isAuth()) {
-            $state.go('layout.login');
-          }
-        }
+        // if(trans.to().authenticate) {
+        //   if(!auth.isAuth()) {
+        //     console.log('layout.login')
+        //     $state.go('layout.login');
+        //   }
+        // }
 
         // move window up on state change
         $window.scrollTo(0, 0);
@@ -53,18 +55,18 @@
         animation.hideAlert();
       });
 
-      Restangular.addFullRequestInterceptor(function (element, operation, what, url, headers, params, httpConfig) {
-        if (auth.isAuth()) {
-          var token = auth.getToken();
-          headers.Authorization = 'Bearer ' + token;
-        }
-        return {
-          element: element,
-          headers: headers,
-          params: params,
-          httpConfig: httpConfig
-        };
-      });
+      // Restangular.addFullRequestInterceptor(function (element, operation, what, url, headers, params, httpConfig) {
+      //   if (auth.isAuth()) {
+      //     var token = auth.getToken();
+      //     headers.Authorization = 'Bearer ' + token;
+      //   }
+      //   return {
+      //     element: element,
+      //     headers: headers,
+      //     params: params,
+      //     httpConfig: httpConfig
+      //   };
+      // });
     }
 
 })();

--- a/src/app/app.route.js
+++ b/src/app/app.route.js
@@ -8,26 +8,27 @@
       Check app.config.js to know how states are protected
     */
 
-    belongsToUser.$inject = ['$window', '$stateParams', 'auth', 'AuthUser', 'deviceUtils', 'userUtils'];
-    function belongsToUser($window, $stateParams, auth, AuthUser, deviceUtils, userUtils) {
-      if(!auth.isAuth() || !$stateParams.id) {
-        return false;
-      }
-      var deviceID = parseInt($stateParams.id);
+    // belongsToUser.$inject = ['$window', '$stateParams', 'auth', 'AuthUser', 'deviceUtils', 'userUtils'];
+    // function belongsToUser($window, $stateParams, auth, AuthUser, deviceUtils, userUtils) {
+    //   console.log('belongsToUser')
+    //   if(!auth.isAuth() || !$stateParams.id) {
+    //     return false;
+    //   }
+    //   var deviceID = parseInt($stateParams.id);
 
-      var userData = ( auth.getCurrentUser().data ) || ($window.localStorage.getItem('smartcitizen.data') && new AuthUser( JSON.parse( $window.localStorage.getItem('smartcitizen.data') )));
-      var belongsToUser = deviceUtils.belongsToUser(userData.devices, deviceID);
-      var isAdmin = userUtils.isAdmin(userData);
-      return isAdmin || belongsToUser;
-    }
+    //   var userData = ( auth.getCurrentUser().data ) || ($window.localStorage.getItem('smartcitizen.data') && new AuthUser( JSON.parse( $window.localStorage.getItem('smartcitizen.data') )));
+    //   var belongsToUser = deviceUtils.belongsToUser(userData.devices, deviceID);
+    //   var isAdmin = userUtils.isAdmin(userData);
+    //   return isAdmin || belongsToUser;
+    // }
 
-    redirectNotOwner.$inject = ['belongsToUser', '$location'];
-    function redirectNotOwner(belongsToUser, $location) {
-      if(!belongsToUser) {
-        console.error('This kit does not belong to user');
-        $location.path('/kits/');
-      }
-    }
+    // redirectNotOwner.$inject = ['belongsToUser', '$location'];
+    // function redirectNotOwner(belongsToUser, $location) {
+    //   if(!belongsToUser) {
+    //     console.error('This kit does not belong to user');
+    //     $location.path('/kits/');
+    //   }
+    // }
 
     config.$inject = ['$stateProvider', '$urlServiceProvider', '$locationProvider', 'RestangularProvider', '$logProvider', '$mdAriaProvider', '$cookiesProvider'];
     function config($stateProvider, $urlServiceProvider, $locationProvider, RestangularProvider, $logProvider, $mdAriaProvider, $cookiesProvider) {
@@ -112,40 +113,39 @@
           controller: 'StaticController',
           controllerAs: 'vm'
         })
-        .state('layout.kitEdit', {
-          url: '/kits/:id/edit?step',
-          templateUrl: 'app/components/kit/editKit/editKit.html',
-          controller: 'EditKitController',
-          controllerAs: 'vm',
-          resolve: {
-            belongsToUser: belongsToUser,
-            redirectNotOwner: redirectNotOwner,
-            step: function($stateParams) {
-              return parseInt($stateParams.step) || 1;
-            }
-          }
-        })
-        .state('layout.kitUpload', {
-          url: '/kits/:id/upload',
-          templateUrl: 'app/components/upload/upload.html',
-          controller: 'UploadController',
-          controllerAs: 'vm',
-          resolve: {
-            belongsToUser: belongsToUser,
-            kit: ['device', 'FullDevice', '$stateParams', function(device, FullDevice, $stateParams) {
-              return device.getDevice($stateParams.id)
-              .then(kit => new FullDevice(kit));
-            }],
-            redirectNotOwner: redirectNotOwner
-         }
-        })
-
-        .state('layout.kitAdd', {
-          url: '/kits/new',
-          templateUrl: 'app/components/kit/newKit/newKit.html',
-          controller: 'NewKitController',
-          controllerAs: 'vm'
-        })
+        // .state('layout.kitEdit', {
+        //   url: '/kits/:id/edit?step',
+        //   templateUrl: 'app/components/kit/editKit/editKit.html',
+        //   controller: 'EditKitController',
+        //   controllerAs: 'vm',
+        //   resolve: {
+        //     belongsToUser: belongsToUser,
+        //     redirectNotOwner: redirectNotOwner,
+        //     step: function($stateParams) {
+        //       return parseInt($stateParams.step) || 1;
+        //     }
+        //   }
+        // })
+        // .state('layout.kitUpload', {
+        //   url: '/kits/:id/upload',
+        //   templateUrl: 'app/components/upload/upload.html',
+        //   controller: 'UploadController',
+        //   controllerAs: 'vm',
+        //   resolve: {
+        //     belongsToUser: belongsToUser,
+        //     kit: ['device', 'FullDevice', '$stateParams', function(device, FullDevice, $stateParams) {
+        //       return device.getDevice($stateParams.id)
+        //       .then(kit => new FullDevice(kit));
+        //     }],
+        //     redirectNotOwner: redirectNotOwner
+        //  }
+        // })
+        // .state('layout.kitAdd', {
+        //   url: '/kits/new',
+        //   templateUrl: 'app/components/kit/newKit/newKit.html',
+        //   controller: 'NewKitController',
+        //   controllerAs: 'vm'
+        // })
 
         /*
         -- Home state --
@@ -187,9 +187,9 @@
               controllerAs: 'tagsCtl'
             }
           },
-          resolve: {
-            belongsToUser:  belongsToUser
-         }
+        //   resolve: {
+        //     belongsToUser:  belongsToUser
+        //  }
         })
         /*
         -- Show Kit state --
@@ -206,9 +206,9 @@
             }
           },
           params: {id: '', reloadMap: false},
-          resolve: {
-            belongsToUser: belongsToUser
-          }
+          // resolve: {
+          //   belongsToUser: belongsToUser
+          // }
         })
         /*
         -- User Profile state --
@@ -216,33 +216,33 @@
         Public profile of a given user
         Redirects to My Profile/My Profile Admin if the user is the one authenticated or if the authenticated user is an admin
         */
-        .state('layout.userProfile', {
-          url: '/users/:id',
-          templateUrl: 'app/components/userProfile/userProfile.html',
-          controller: 'UserProfileController',
-          controllerAs: 'vm',
-          resolve: {
-            isCurrentUser: function($stateParams, $location, auth) {
-              if(!auth.isAuth()) {
-                return;
-              }
-              var userID = parseInt($stateParams.id);
-              var authUserID = auth.getCurrentUser().data && auth.getCurrentUser().data.id;
-              if(userID === authUserID) {
-                $location.path('/profile');
-              }
-            },
-            isAdmin: function($window, $location, $stateParams, auth, AuthUser) {
-              var userRole = (auth.getCurrentUser().data && auth.getCurrentUser().data.role) || ($window.localStorage.getItem('smartcitizen.data') && new AuthUser(JSON.parse( $window.localStorage.getItem('smartcitizen.data') )).role);
-              if(userRole === 'admin') {
-                var userID = $stateParams.id;
-                $location.path('/profile/' + userID);
-              } else {
-                return false;
-              }
-            }
-          }
-        })
+        // .state('layout.userProfile', {
+        //   url: '/users/:id',
+        //   templateUrl: 'app/components/userProfile/userProfile.html',
+        //   controller: 'UserProfileController',
+        //   controllerAs: 'vm',
+        //   resolve: {
+        //     isCurrentUser: function($stateParams, $location, auth) {
+        //       if(!auth.isAuth()) {
+        //         return;
+        //       }
+        //       var userID = parseInt($stateParams.id);
+        //       var authUserID = auth.getCurrentUser().data && auth.getCurrentUser().data.id;
+        //       if(userID === authUserID) {
+        //         $location.path('/profile');
+        //       }
+        //     },
+        //     isAdmin: function($window, $location, $stateParams, auth, AuthUser) {
+        //       var userRole = (auth.getCurrentUser().data && auth.getCurrentUser().data.role) || ($window.localStorage.getItem('smartcitizen.data') && new AuthUser(JSON.parse( $window.localStorage.getItem('smartcitizen.data') )).role);
+        //       if(userRole === 'admin') {
+        //         var userID = $stateParams.id;
+        //         $location.path('/profile/' + userID);
+        //       } else {
+        //         return false;
+        //       }
+        //     }
+        //   }
+        // })
         /*
         -- My Profile state --
         Private profile of the authenticated user at the moment
@@ -323,57 +323,58 @@
         -- Login --
         It redirects to a certain kit state and opens the login dialog automatically
         */
-        .state('layout.login', {
-          url: '/login',
-          authenticate: false,
-          resolve: {
-            buttonToClick: function($location, auth) {
-              // TODO: Bug These transitions get rejected (console error)
-              if(auth.isAuth()) {
-                $location.path('/kits/');
-              }else{
-                $location.path('/kits/');
-                $location.search('login', 'true');
-              }
-            }
-          }
-        })
+        // .state('layout.login', {
+        //   url: '/login',
+        //   authenticate: false,
+        //   resolve: {
+        //     buttonToClick: function($location, auth) {
+        //       // TODO: Bug These transitions get rejected (console error)
+        //       if(auth.isAuth()) {
+        //         $location.path('/kits/');
+        //       }else{
+        //         $location.path('/kits/');
+        //         $location.search('login', 'true');
+        //       }
+        //     }
+        //   }
+        // })
         /*
         -- Signup --
         It redirects to a certain kit state and opens the signup dialog automatically
         */
-        .state('layout.signup', {
-          url: '/signup',
-          authenticate: false,
-          resolve: {
-            buttonToClick: function($location, auth) {
-              if(auth.isAuth()) {
-                return $location.path('/kits/');
-              }
-              $location.path('/kits/');
-              $location.search('signup', 'true');
-            }
-          }
-        })
+        // .state('layout.signup', {
+        //   url: '/signup',
+        //   authenticate: false,
+        //   resolve: {
+        //     buttonToClick: function($location, auth) {
+        //       if(auth.isAuth()) {
+        //         return $location.path('/kits/');
+        //       }
+        //       $location.path('/kits/');
+        //       $location.search('signup', 'true');
+        //     }
+        //   }
+        // })
         /*
         -- Logout --
         It removes all the user data from localstorage and redirects to landing state
         */
-        .state('logout', {
-          url: '/logout',
-          authenticate: true,
-          resolve: {
-            logout: function($location, $state, auth, $rootScope) {
-              auth.logout();
-              $location.path('/kits/');
-              $rootScope.$broadcast('loggedOut');
-            }
-          }
-        })
+        // .state('logout', {
+        //   url: '/logout',
+        //   authenticate: true,
+        //   resolve: {
+        //     logout: function($location, $state, auth, $rootScope) {
+        //       auth.logout();
+        //       $location.path('/kits/');
+        //       $rootScope.$broadcast('loggedOut');
+        //     }
+        //   }
+        // })
         /*
         -- Password Recovery --
         Form to input your email address to receive an email to reset your password
         */
+      //  TODO REMOVE
         .state('passwordRecovery', {
           url: '/password_reset',
           authenticate: false,
@@ -386,6 +387,7 @@
         This link will be given by the email you received after giving your email in the previous state
         Here, you can input your new password
         */
+      //  TODO REMOVE
         .state('passwordReset', {
           url: '/password_reset/:code',
           authenticate: false,
@@ -407,7 +409,6 @@
       $urlServiceProvider.rules.when('/profile', '/profile/kits');
       $urlServiceProvider.rules.when('/profile/:id', '/profile/:id/kits');
 
-
       /* Default profile state */
       $locationProvider.html5Mode({
         enabled: true,
@@ -416,6 +417,8 @@
 
       /*  Sets the default Smart Citizen API base url */
       RestangularProvider.setBaseUrl('https://api.smartcitizen.me/v0');
+      // RestangularProvider.setBaseUrl('https://staging-api.smartcitizen.me/v0')
+      RestangularProvider.setDefaultHttpFields({withCredentials: true});
       //RestangularProvider.setBaseUrl('http://localhost:3000/v0');
 
       /* Remove angular leaflet logs */

--- a/src/app/components/components.module.js
+++ b/src/app/components/components.module.js
@@ -1,6 +1,5 @@
 (function() {
 	'use strict';
 
-
 	angular.module('app.components', []);
 })();

--- a/src/app/components/kit/editKit/editKit.controller.js
+++ b/src/app/components/kit/editKit/editKit.controller.js
@@ -23,264 +23,279 @@
   angular.module('app.components')
     .controller('EditKitController', EditKitController);
 
-    EditKitController.$inject = ['$scope', '$element', '$location', '$timeout', '$state',
-    'animation','auth','device', 'tag', 'alert', 'step', '$stateParams', 'FullDevice'];
-    function EditKitController($scope, $element, $location, $timeout, $state, animation,
-      auth, device, tag, alert, step, $stateParams, FullDevice) {
+    EditKitController.$inject = ['$scope', '$window', '$location', '$stateParams', 'URLS', 'AuthUser', 'urlUtils', 'user'];
+    function EditKitController($scope,  $window, $location, $stateParams, URLS, AuthUser, urlUtils, user) {
+
+      var ui_base_url = URLS['base'];
+      var device_edit_path = URLS['devices:id:edit'];
 
       var vm = this;
+      vm.device_id = $stateParams.id;
 
-      // WAIT INTERVAL FOR USER FEEDBACK and TRANSITIONS (This will need to change)
-      var timewait = {
-          long: 5000,
-          normal: 2000,
-          short: 1000
-      };
-
-      vm.step = step;
-
-      // KEY USER ACTIONS
-      vm.submitFormAndKit = submitFormAndKit;
-      vm.backToProfile = backToProfile;
-      vm.backToDevice = backToDevice;
-      vm.submitForm = submitForm;
-      vm.goToStep = goToStep;
-      vm.nextAction = 'save';
-
-      // EXPOSURE SELECT
-      vm.exposure = [
-        {name: 'indoor', value: 1},
-        {name: 'outdoor', value: 2}
-      ];
-
-      // FORM INFO
-      vm.deviceForm = {};
-      vm.device = undefined;
-
-      $scope.clearSearchTerm = function() {
-        $scope.searchTerm = '';
-      };
-      // The md-select directive eats keydown events for some quick select
-      // logic. Since we have a search input here, we don't need that logic.
-      $element.find('input').on('keydown', function(ev) {
-          ev.stopPropagation();
-      });
-
-      $scope.$on('leafletDirectiveMarker.dragend', function(event, args){
-        vm.deviceForm.location.lat = args.model.lat;
-        vm.deviceForm.location.lng = args.model.lng;
-      });
-
-      // MAP CONFIGURATION
-      var mapBoxToken = 'pk.eyJ1IjoidG9tYXNkaWV6IiwiYSI6ImRTd01HSGsifQ.loQdtLNQ8GJkJl2LUzzxVg';
-
-      vm.getLocation = getLocation;
-      vm.markers = {};
-      vm.tiles = {
-        url: 'https://api.mapbox.com/styles/v1/mapbox/streets-v10/tiles/{z}/{x}/{y}?access_token=' + mapBoxToken
-      };
-      vm.defaults = {
-        scrollWheelZoom: false
-      };
-
-      initialize();
-
-      /////////////////
-
-      function initialize() {
-        var deviceID = $stateParams.id;
-
-        animation.viewLoaded();
-        getTags();
-
-        if (!deviceID || deviceID === ''){
-          return;
-        }
-        device.getDevice(deviceID)
-          .then(function(deviceData) {
-            vm.device = new FullDevice(deviceData);
-            vm.userRole = auth.getCurrentUser().data.role;
-            vm.deviceForm = {
-              name: vm.device.name,
-              exposure: findExposureFromLabels(vm.device.systemTags),
-              location: {
-                lat: vm.device.location.latitude,
-                lng: vm.device.location.longitude,
-                zoom: 16
-              },
-              is_private: vm.device.isPrivate,
-              precise_location: vm.device.preciseLocation,
-              enable_forwarding: vm.device.enableForwarding,
-              notify_low_battery: vm.device.notifications.lowBattery,
-              notify_stopped_publishing: vm.device.notifications.stopPublishing,
-              tags: vm.device.userTags,
-              postprocessing: vm.device.postProcessing,
-              description: vm.device.description,
-              hardwareName: vm.device.hardware.name
-            };
-            vm.markers = {
-              main: {
-                lat: vm.device.location.latitude,
-                lng: vm.device.location.longitude,
-                draggable: true
-              }
-            };
-
-            if (vm.device.isLegacy) {
-              vm.deviceForm.macAddress = vm.device.macAddress;
-            }
-          });
-      }
-
-      // Return tags in a comma separated list
-      function joinSelectedTags(){
-        let tmp = []
-        $scope.selectedTags.forEach(function(e){
-          tmp.push(e.name)
-        })
-        return tmp.join(', ');
-      }
-
-      function getLocation() {
-        window.navigator.geolocation.getCurrentPosition(function(position) {
-          $scope.$apply(function() {
-            var lat = position.coords.latitude;
-            var lng = position.coords.longitude;
-            vm.deviceForm.location.lat = lat;
-            vm.deviceForm.location.lng = lng;
-            vm.markers.main.lat = lat;
-            vm.markers.main.lng = lng;
-          });
-        });
-      }
-
-      function submitFormAndKit(){
-        submitForm(backToProfile, timewait.normal);
-      }
-
-      function submitForm(next, delayTransition) {
-        var data = {
-          name: vm.deviceForm.name,
-          description: vm.deviceForm.description,
-          postprocessing_attributes: vm.deviceForm.postprocessing,
-          exposure: findExposure(vm.deviceForm.exposure),
-          latitude: vm.deviceForm.location.lat,
-          longitude: vm.deviceForm.location.lng,
-          is_private: vm.deviceForm.is_private,
-          enable_forwarding: vm.deviceForm.enable_forwarding,
-          precise_location: vm.deviceForm.precise_location,
-          notify_low_battery: vm.deviceForm.notify_low_battery,
-          notify_stopped_publishing: vm.deviceForm.notify_stopped_publishing,
-          mac_address: "",
-          /*jshint camelcase: false */
-          user_tags: joinSelectedTags(),
-        };
-
-        vm.errors={};
-
-        if(!vm.device.isSCK) {
-          data.hardware_name_override = vm.deviceForm.hardwareName;
-        }
-
-        // Workaround for the mac_address bypass
-        // If mac_address is "", we get an error on the request -> we use it for the newKit
-        // If mac_address is null, no problem -> we use it for the
-        if ($stateParams.step === "2") {
-          data.mac_address = vm.deviceForm.macAddress ? vm.deviceForm.macAddress : "";
-        } else {
-          data.mac_address = vm.deviceForm.macAddress ? vm.deviceForm.macAddress : null;
-        }
-
-        device.updateDevice(vm.device.id, data)
-          .then(
-            function() {
-
-              if (next){
-                alert.success('Your kit was updated!');
-              }
-
-              device.updateContext().then(function(){
-                if (next){
-                  $timeout(next, delayTransition);
-                }
-              });
-            })
-            .catch(function(err) {
-              if(err.data.errors) {
-                vm.errors = err.data.errors;
-                var message = Object.keys(vm.errors).map(function (key, _) {
-                  return [key, vm.errors[key][0]].join(' '); }).join('');
-                alert.error('Oups! Check the input. Something went wrong!');
-                throw new Error('[Client:error] ' + message);
-              }
-              $timeout(function(){ }, timewait.long);
-            });
-      }
-
-      function findExposureFromLabels(labels){
-        var label = vm.exposure.filter(function(n) {
-            return labels.indexOf(n.name) !== -1;
-        })[0];
-        if(label) {
-          return findExposure(label.name);
-        } else {
-          return findExposure(vm.exposure[0].name);
-        }
-      }
-
-      function findExposure(nameOrValue) {
-        var findProp, resultProp;
-
-        //if it's a string
-        if(isNaN(parseInt(nameOrValue))) {
-          findProp = 'name';
-          resultProp = 'value';
-        } else {
-          findProp = 'value';
-          resultProp = 'name';
-        }
-
-        var option = _.find(vm.exposure, function(exposureFromList) {
-          return exposureFromList[findProp] === nameOrValue;
-        });
-        if(option) {
-          return option[resultProp];
-        } else {
-          return vm.exposure[0][resultProp];
-        }
-      }
-
-      function getTags() {
-        tag.getTags()
-          .then(function(tagsData) {
-            vm.tags = tagsData;
-          });
-      }
-
-      function backToProfile(){
-        $state.transitionTo('layout.myProfile.kits', $stateParams,
-        { reload: false,
-          inherit: false,
-          notify: true
-        });
-      }
-
-      function backToDevice(){
-        $state.transitionTo('layout.home.kit', $stateParams,
-        { reload: false,
-          inherit: false,
-          notify: true
-        });
-      }
-
-      function goToStep(step) {
-        vm.step = step;
-        $state.transitionTo('layout.kitEdit', { id:$stateParams.id, step: step} ,
-        {
-          reload: false,
-          inherit: false,
-          notify: false
-        });
-      }
+      $window.location.href = ui_base_url + urlUtils.get_path(device_edit_path, ":id" , vm.device_id);
     }
+
+//   angular.module('app.components')
+//     .controller('EditKitController', EditKitController);
+
+//     EditKitController.$inject = ['$scope', '$element', '$location', '$timeout', '$state',
+//     'animation','auth','device', 'tag', 'alert', 'step', '$stateParams', 'FullDevice'];
+//     function EditKitController($scope, $element, $location, $timeout, $state, animation,
+//       auth, device, tag, alert, step, $stateParams, FullDevice) {
+
+//       var vm = this;
+
+//       // WAIT INTERVAL FOR USER FEEDBACK and TRANSITIONS (This will need to change)
+//       var timewait = {
+//           long: 5000,
+//           normal: 2000,
+//           short: 1000
+//       };
+
+//       vm.step = step;
+
+//       // KEY USER ACTIONS
+//       vm.submitFormAndKit = submitFormAndKit;
+//       vm.backToProfile = backToProfile;
+//       vm.backToDevice = backToDevice;
+//       vm.submitForm = submitForm;
+//       vm.goToStep = goToStep;
+//       vm.nextAction = 'save';
+
+//       // EXPOSURE SELECT
+//       vm.exposure = [
+//         {name: 'indoor', value: 1},
+//         {name: 'outdoor', value: 2}
+//       ];
+
+//       // FORM INFO
+//       vm.deviceForm = {};
+//       vm.device = undefined;
+
+//       $scope.clearSearchTerm = function() {
+//         $scope.searchTerm = '';
+//       };
+//       // The md-select directive eats keydown events for some quick select
+//       // logic. Since we have a search input here, we don't need that logic.
+//       $element.find('input').on('keydown', function(ev) {
+//           ev.stopPropagation();
+//       });
+
+//       $scope.$on('leafletDirectiveMarker.dragend', function(event, args){
+//         vm.deviceForm.location.lat = args.model.lat;
+//         vm.deviceForm.location.lng = args.model.lng;
+//       });
+
+//       // MAP CONFIGURATION
+//       var mapBoxToken = 'pk.eyJ1IjoidG9tYXNkaWV6IiwiYSI6ImRTd01HSGsifQ.loQdtLNQ8GJkJl2LUzzxVg';
+
+//       vm.getLocation = getLocation;
+//       vm.markers = {};
+//       vm.tiles = {
+//         url: 'https://api.mapbox.com/styles/v1/mapbox/streets-v10/tiles/{z}/{x}/{y}?access_token=' + mapBoxToken
+//       };
+//       vm.defaults = {
+//         scrollWheelZoom: false
+//       };
+
+//       initialize();
+
+//       /////////////////
+
+//       function initialize() {
+//         var deviceID = $stateParams.id;
+
+//         animation.viewLoaded();
+//         getTags();
+
+//         if (!deviceID || deviceID === ''){
+//           return;
+//         }
+//         device.getDevice(deviceID)
+//           .then(function(deviceData) {
+//             vm.device = new FullDevice(deviceData);
+//             vm.userRole = auth.getCurrentUser().data.role;
+//             vm.deviceForm = {
+//               name: vm.device.name,
+//               exposure: findExposureFromLabels(vm.device.systemTags),
+//               location: {
+//                 lat: vm.device.location.latitude,
+//                 lng: vm.device.location.longitude,
+//                 zoom: 16
+//               },
+//               is_private: vm.device.isPrivate,
+//               precise_location: vm.device.preciseLocation,
+//               enable_forwarding: vm.device.enableForwarding,
+//               notify_low_battery: vm.device.notifications.lowBattery,
+//               notify_stopped_publishing: vm.device.notifications.stopPublishing,
+//               tags: vm.device.userTags,
+//               postprocessing: vm.device.postProcessing,
+//               description: vm.device.description,
+//               hardwareName: vm.device.hardware.name
+//             };
+//             vm.markers = {
+//               main: {
+//                 lat: vm.device.location.latitude,
+//                 lng: vm.device.location.longitude,
+//                 draggable: true
+//               }
+//             };
+
+//             if (vm.device.isLegacy) {
+//               vm.deviceForm.macAddress = vm.device.macAddress;
+//             }
+//           });
+//       }
+
+//       // Return tags in a comma separated list
+//       function joinSelectedTags(){
+//         let tmp = []
+//         $scope.selectedTags.forEach(function(e){
+//           tmp.push(e.name)
+//         })
+//         return tmp.join(', ');
+//       }
+
+//       function getLocation() {
+//         window.navigator.geolocation.getCurrentPosition(function(position) {
+//           $scope.$apply(function() {
+//             var lat = position.coords.latitude;
+//             var lng = position.coords.longitude;
+//             vm.deviceForm.location.lat = lat;
+//             vm.deviceForm.location.lng = lng;
+//             vm.markers.main.lat = lat;
+//             vm.markers.main.lng = lng;
+//           });
+//         });
+//       }
+
+//       function submitFormAndKit(){
+//         submitForm(backToProfile, timewait.normal);
+//       }
+
+//       function submitForm(next, delayTransition) {
+//         var data = {
+//           name: vm.deviceForm.name,
+//           description: vm.deviceForm.description,
+//           postprocessing_attributes: vm.deviceForm.postprocessing,
+//           exposure: findExposure(vm.deviceForm.exposure),
+//           latitude: vm.deviceForm.location.lat,
+//           longitude: vm.deviceForm.location.lng,
+//           is_private: vm.deviceForm.is_private,
+//           enable_forwarding: vm.deviceForm.enable_forwarding,
+//           precise_location: vm.deviceForm.precise_location,
+//           notify_low_battery: vm.deviceForm.notify_low_battery,
+//           notify_stopped_publishing: vm.deviceForm.notify_stopped_publishing,
+//           mac_address: "",
+//           /*jshint camelcase: false */
+//           user_tags: joinSelectedTags(),
+//         };
+
+//         vm.errors={};
+
+//         if(!vm.device.isSCK) {
+//           data.hardware_name_override = vm.deviceForm.hardwareName;
+//         }
+
+//         // Workaround for the mac_address bypass
+//         // If mac_address is "", we get an error on the request -> we use it for the newKit
+//         // If mac_address is null, no problem -> we use it for the
+//         if ($stateParams.step === "2") {
+//           data.mac_address = vm.deviceForm.macAddress ? vm.deviceForm.macAddress : "";
+//         } else {
+//           data.mac_address = vm.deviceForm.macAddress ? vm.deviceForm.macAddress : null;
+//         }
+
+//         device.updateDevice(vm.device.id, data)
+//           .then(
+//             function() {
+
+//               if (next){
+//                 alert.success('Your kit was updated!');
+//               }
+
+//               device.updateContext().then(function(){
+//                 if (next){
+//                   $timeout(next, delayTransition);
+//                 }
+//               });
+//             })
+//             .catch(function(err) {
+//               if(err.data.errors) {
+//                 vm.errors = err.data.errors;
+//                 var message = Object.keys(vm.errors).map(function (key, _) {
+//                   return [key, vm.errors[key][0]].join(' '); }).join('');
+//                 alert.error('Oups! Check the input. Something went wrong!');
+//                 throw new Error('[Client:error] ' + message);
+//               }
+//               $timeout(function(){ }, timewait.long);
+//             });
+//       }
+
+//       function findExposureFromLabels(labels){
+//         var label = vm.exposure.filter(function(n) {
+//             return labels.indexOf(n.name) !== -1;
+//         })[0];
+//         if(label) {
+//           return findExposure(label.name);
+//         } else {
+//           return findExposure(vm.exposure[0].name);
+//         }
+//       }
+
+//       function findExposure(nameOrValue) {
+//         var findProp, resultProp;
+
+//         //if it's a string
+//         if(isNaN(parseInt(nameOrValue))) {
+//           findProp = 'name';
+//           resultProp = 'value';
+//         } else {
+//           findProp = 'value';
+//           resultProp = 'name';
+//         }
+
+//         var option = _.find(vm.exposure, function(exposureFromList) {
+//           return exposureFromList[findProp] === nameOrValue;
+//         });
+//         if(option) {
+//           return option[resultProp];
+//         } else {
+//           return vm.exposure[0][resultProp];
+//         }
+//       }
+
+//       function getTags() {
+//         tag.getTags()
+//           .then(function(tagsData) {
+//             vm.tags = tagsData;
+//           });
+//       }
+
+//       function backToProfile(){
+//         $state.transitionTo('layout.myProfile.kits', $stateParams,
+//         { reload: false,
+//           inherit: false,
+//           notify: true
+//         });
+//       }
+
+//       function backToDevice(){
+//         $state.transitionTo('layout.home.kit', $stateParams,
+//         { reload: false,
+//           inherit: false,
+//           notify: true
+//         });
+//       }
+
+//       function goToStep(step) {
+//         vm.step = step;
+//         $state.transitionTo('layout.kitEdit', { id:$stateParams.id, step: step} ,
+//         {
+//           reload: false,
+//           inherit: false,
+//           notify: false
+//         });
+//       }
+//     }
 })();

--- a/src/app/components/kit/showKit/showKit.controller.js
+++ b/src/app/components/kit/showKit/showKit.controller.js
@@ -5,15 +5,15 @@
     .controller('KitController', KitController);
 
   KitController.$inject = ['$state','$scope', '$stateParams',
-    'sensor', 'FullDevice', '$mdDialog', 'belongsToUser',
+    'sensor', 'FullDevice', '$mdDialog',
     'timeUtils', 'animation', 'auth',
-    '$timeout', 'alert', '$q', 'device',
-    'HasSensorDevice', 'geolocation', 'PreviewDevice'];
+    '$timeout', 'alert', '$q', 'device', 'deviceUtils',
+    'HasSensorDevice', 'geolocation', 'PreviewDevice', 'userUtils', 'urlUtils', 'URLS'];
   function KitController($state, $scope, $stateParams,
-    sensor, FullDevice, $mdDialog, belongsToUser,
+    sensor, FullDevice, $mdDialog,
     timeUtils, animation, auth,
-    $timeout, alert, $q, device,
-    HasSensorDevice, geolocation, PreviewDevice) {
+    $timeout, alert, $q, device, deviceUtils,
+    HasSensorDevice, geolocation, PreviewDevice, userUtils, urlUtils, URLS) {
 
     var vm = this;
     var sensorsData = [];
@@ -25,16 +25,16 @@
     vm.downloadData = downloadData;
     vm.geolocate = geolocate;
     vm.device = undefined;
-    vm.deviceBelongsToUser = belongsToUser;
+    // vm.deviceBelongsToUser = belongsToUser;
     vm.deviceWithoutData = false;
-    vm.legacyApiKey = belongsToUser ?
-      auth.getCurrentUser().data.key :
-      undefined;
+    // vm.legacyApiKey = belongsToUser ?
+    //   auth.getCurrentUser().data.key :
+    //   undefined;
     vm.loadingChart = true;
     vm.moveChart = moveChart;
     vm.allowUpdateChart = true;
     vm.ownerDevices = [];
-    vm.removeDevice = removeDevice;
+    // vm.removeDevice = removeDevice;
     vm.resetTimeOpts = resetTimeOpts;
     vm.sampleDevices = [];
     vm.selectedSensor = undefined;
@@ -119,8 +119,39 @@
       initialize();
     });
 
+    function belongsToUser() {
+      // console.log('belongsToUser')
+      if(!auth.isAuth() || !$stateParams.id) {
+        // console.log('Not auth')
+        // console.log(!auth.isAuth());
+        // console.log(!$stateParams.id)
+        return false;
+      }
+      var deviceID = parseInt($stateParams.id);
+      // console.log(deviceID)
+
+      var userData = ( auth.getCurrentUser().data ) || ($window.localStorage.getItem('smartcitizen.data') && new AuthUser( JSON.parse( $window.localStorage.getItem('smartcitizen.data') )));
+      var belongsToUser = deviceUtils.belongsToUser(userData.devices, deviceID);
+      var isAdmin = userUtils.isAdmin(userData);
+      return isAdmin || belongsToUser;
+    }
+
+    redirectNotOwner.$inject = ['belongsToUser', '$location'];
+    function redirectNotOwner(belongsToUser, $location) {
+      if(!belongsToUser) {
+        // console.error('This kit does not belong to user');
+        $location.path('/kits/');
+      }
+    }
+
+    $scope.$on('loggedIn', function(event){
+      vm.deviceBelongsToUser = belongsToUser();
+    });
+
     function initialize() {
+      vm.deviceBelongsToUser = belongsToUser();
       animation.viewLoaded();
+      // vm.deviceBelongsToUser = belongsToUser();
       updatePeriodically();
     }
 
@@ -162,6 +193,18 @@
             vm.device = newDevice;
             setOwnerSampleDevices();
 
+            // NEW MONOLITH INTEGRATION
+            var ui_base_url = URLS['base']
+            var user_path = URLS['users:username']
+            var device_edit_path = URLS['devices:id:edit']
+            var device_download_path = URLS['devices:id:download']
+            var device_upload_path = URLS['devices:id:upload']
+
+            vm.user_url = ui_base_url + urlUtils.get_path(user_path, ":username", vm.device.owner.username);
+            vm.device_edit_url = ui_base_url + urlUtils.get_path(device_edit_path, ":id", vm.device.id);
+            vm.device_download_url = ui_base_url + urlUtils.get_path(device_download_path, ":id", vm.device.id);
+            vm.device_upload_url = ui_base_url + urlUtils.get_path(device_upload_path, ":id", vm.device.id);
+
             if (vm.device.state.name === 'has published') {
               /* Device has data */
               setDeviceOnMap();
@@ -190,6 +233,7 @@
           });
         }
         else if (error.noSensorData) {
+          // console.log('deviceHasNoData')
           deviceHasNoData();
         }
         else if (error.status === 403){
@@ -281,36 +325,36 @@
       }
     }
 
-    function removeDevice() {
-      var confirm = $mdDialog.confirm()
-        .title('Delete this kit?')
-        .textContent('Are you sure you want to delete this kit?')
-        .ariaLabel('')
-        .ok('DELETE')
-        .cancel('Cancel')
-        .theme('primary')
-        .clickOutsideToClose(true);
+    // function removeDevice() {
+    //   var confirm = $mdDialog.confirm()
+    //     .title('Delete this kit?')
+    //     .textContent('Are you sure you want to delete this kit?')
+    //     .ariaLabel('')
+    //     .ok('DELETE')
+    //     .cancel('Cancel')
+    //     .theme('primary')
+    //     .clickOutsideToClose(true);
 
-      $mdDialog
-        .show(confirm)
-        .then(function(){
-          device
-            .removeDevice(vm.device.id)
-            .then(function(){
-              alert.success('Your kit was deleted successfully');
-              device.updateContext().then(function(){
-                $state.transitionTo('layout.myProfile.kits', $stateParams,
-                  { reload: false,
-                    inherit: false,
-                    notify: true
-                  });
-              });
-            })
-            .catch(function(){
-              alert.error('Error trying to delete your kit.');
-            });
-        });
-    }
+    //   $mdDialog
+    //     .show(confirm)
+    //     .then(function(){
+    //       device
+    //         .removeDevice(vm.device.id)
+    //         .then(function(){
+    //           alert.success('Your kit was deleted successfully');
+    //           device.updateContext().then(function(){
+    //             $state.transitionTo('layout.myProfile.kits', $stateParams,
+    //               { reload: false,
+    //                 inherit: false,
+    //                 notify: true
+    //               });
+    //           });
+    //         })
+    //         .catch(function(){
+    //           alert.error('Error trying to delete your kit.');
+    //         });
+    //     });
+    // }
 
     function showSensorOnChart(sensorID) {
       vm.selectedSensor = sensorID;

--- a/src/app/components/kit/showKit/showKit.html
+++ b/src/app/components/kit/showKit/showKit.html
@@ -13,7 +13,7 @@
           <div hide show-gt-xs class="kit_user">
             <md-tooltip md-direction="top">Visit user profile</md-tooltip>
             <img ng-src="{{ vm.device.owner.profile_picture || './assets/images/avatar.svg'}}" />
-            <a href="./users/{{vm.device.owner.id}}"><span>{{ vm.device.owner.username}}</span></a>
+            <a href="{{vm.user_url}}"><span>{{ vm.device.owner.username}}</span></a>
           </div>
           <div hide show-gt-xs class="kit_name">
             <md-icon md-svg-src="./assets/images/sensor_icon.svg" class="sensor_icon"></md-icon>
@@ -223,16 +223,19 @@
               <div class="kit_details_manage" ng-if="vm.deviceBelongsToUser">
                 <h3>Manage your kit</h3>
                 <div class="kit_details_manage_buttons">
-                  <md-button class="md-primary md-raised md-hue-1" ui-sref="layout.kitEdit({id: vm.device.id})" aria-label=""><md-icon style="margin-right:5px" md-font-icon="fa fa-edit"></md-icon><span>EDIT</span></md-button>
-                  <md-button class="md-primary md-raised md-hue-1" ng-click="vm.downloadData(vm.device)">
-                    <md-icon style="margin-right:5px" 15px class="md-primary md-raised kit_detailed_icon_content" md-font-icon="fa fa-download" ng-click="vm.downloadData(vm.device)"> </md-icon>
+
+                  <md-button class="md-primary md-raised md-hue-1" href="{{vm.device_edit_url}}" aria-label=""><md-icon style="margin-right:5px" md-font-icon="fa fa-edit"></md-icon><span>EDIT</span></md-button>
+
+                  <md-button class="md-primary md-raised md-hue-1" href="{{vm.device_download_url}}">
+                    <md-icon style="margin-right:5px" 15px class="md-primary md-raised kit_detailed_icon_content" md-font-icon="fa fa-download"> </md-icon>
                     Download CSV
                   </md-button>
+
                   <!-- <md-button class="md-primary md-raised md-hue-1" ng-if="vm.device.isLegacy" ui-sref="layout.kitEdit({step: 2, id: vm.device.id})" aria-label="">
                     <md-icon style="margin-right:5px" md-font-icon="fa fa-wrench"></md-icon><span>SET UP!</span></md-button> -->
-                  <md-button class="md-primary md-raised md-hue-1" ng-if="vm.device.hardware" ui-sref="layout.kitUpload({id: vm.device.id})" aria-label="">
+                  <md-button class="md-primary md-raised md-hue-1" ng-if="vm.device.hardware" href="{{vm.device_upload_url}}" aria-label="">
                     <md-icon style="margin-right:5px" md-font-icon="fa fa-sd-card"></md-icon><span>SD CARD UPLOAD</span></md-button>
-                  <md-button class="md-primary md-raised md-hue-1" ng-click="vm.removeDevice()" aria-label=""> <md-icon style="margin-right:5px" md-font-icon="fa fa-trash"></md-icon><span>DELETE</span></md-button>
+
                 </div>
               </div>
             <div ng-if="!vm.deviceBelongsToUser">
@@ -249,7 +252,7 @@
           <div layout="row" layout-align="start center">
             <img class="ml-20 mr-30" style="height:100px; border-radius:50px;" ng-src="{{ vm.device.owner.profile_picture || './assets/images/avatar.svg' }}" />
             <div>
-              <a href="./users/{{vm.device.owner.id}}" class="kit_owner_usernameLink">
+              <a href="{{vm.user_url}}" class="kit_owner_usernameLink">
                 <h2 class="kit_owner_usernameText">{{ vm.device.owner.username }}</h2>
               </a>
               <p>

--- a/src/app/components/layout/layout.controller.js
+++ b/src/app/components/layout/layout.controller.js
@@ -4,9 +4,14 @@
   angular.module('app.components')
     .controller('LayoutController', LayoutController);
 
-    LayoutController.$inject = ['$mdSidenav','$mdDialog', '$location', '$state', '$scope', '$transitions', 'auth', 'animation', '$timeout', 'DROPDOWN_OPTIONS_COMMUNITY', 'DROPDOWN_OPTIONS_USER'];
-    function LayoutController($mdSidenav, $mdDialog, $location, $state, $scope, $transitions, auth, animation, $timeout, DROPDOWN_OPTIONS_COMMUNITY, DROPDOWN_OPTIONS_USER) {
+    LayoutController.$inject = ['$mdSidenav','$mdDialog', '$location', '$rootScope', '$state', '$scope', '$transitions', '$window', 'auth', 'animation', '$timeout', 'urlUtils', 'DROPDOWN_OPTIONS_COMMUNITY', 'URLS'];
+    function LayoutController($mdSidenav, $mdDialog, $location, $rootScope, $state, $scope, $transitions, $window, auth, animation, $timeout, urlUtils, DROPDOWN_OPTIONS_COMMUNITY, URLS) {
       var vm = this;
+      vm.ui_base_url = URLS['base']
+      var goto_path = URLS['goto']
+
+      vm.logout_url = vm.ui_base_url + URLS['logout']+ urlUtils.get_path(goto_path, ":url" , $window.location);
+      vm.seeed_url = URLS['seeed']
 
       vm.navRightLayout = 'space-around center';
 
@@ -42,7 +47,11 @@
         vm.isShown = true;
         angular.element('.nav_right .wrap-dd-menu').css('display', 'initial');
         vm.currentUser = auth.getCurrentUser().data;
-        vm.dropdownOptions[0].text = 'Hi, ' + vm.currentUser.username + '!';
+        var user_path = URLS['users:username']
+        vm.user_url = vm.ui_base_url + urlUtils.get_path(user_path, ":username", vm.currentUser.username);
+
+        // console.log(vm.dropdownOptions)
+
         vm.navRightLayout = 'end center';
         if(!$scope.$$phase) {
           $scope.$digest();
@@ -62,7 +71,6 @@
       vm.isLoggedin = false;
       vm.logout = logout;
 
-      vm.dropdownOptions = DROPDOWN_OPTIONS_USER;
       vm.dropdownSelected = undefined;
 
       vm.dropdownOptionsCommunity = DROPDOWN_OPTIONS_COMMUNITY;
@@ -94,8 +102,10 @@
       }
 
       function logout() {
-        auth.logout();
+        // auth.logout();
         vm.isLoggedin = false;
+        $rootScope.$broadcast('loggedOut');
+        $window.location.href = vm.logout_url;
       }
     }
 })();

--- a/src/app/components/layout/layout.html
+++ b/src/app/components/layout/layout.html
@@ -46,9 +46,19 @@
         </md-button>
 
         <md-menu-content ng-mouseleave="$mdMenu.close()">
-          <md-menu-item ng-repeat="item in vm.dropdownOptions">
-            <md-button href="{{item.href}}">
-              {{item.text}}
+          <md-menu-item>
+            <md-button href="{{vm.user_url}}">
+              Hi, {{vm.currentUser.username}}!
+            </md-button>
+          </md-menu-item>
+          <md-menu-item>
+            <md-button href="{{vm.user_url}}">
+              My profile
+            </md-button>
+          </md-menu-item>
+          <md-menu-item>
+            <md-button ng-click="vm.logout()">
+              Log out
             </md-button>
           </md-menu-item>
         </md-menu-content>
@@ -75,8 +85,8 @@
     <md-content>
       <md-menu-item ng-show="vm.isShown && !vm.isLoggedin" login class=""></md-menu-item>
       <md-menu-item ng-show="vm.isShown && !vm.isLoggedin" signup class=""></md-menu-item>
-      <md-menu-item ng-show="vm.isLoggedin"> <md-button href="./profile">Profile</md-button> </md-menu-item>
-      <md-menu-item ng-show="vm.isLoggedin"> <md-button href="./logout"> Log out </md-button> </md-menu-item>
+      <md-menu-item ng-show="vm.isLoggedin"> <md-button href="{{vm.user_url}}">Profile</md-button> </md-menu-item>
+      <md-menu-item ng-show="vm.isLoggedin"> <md-button ng-click="vm.logout()"> Log out </md-button> </md-menu-item>
       <md-divider> </md-divider>
 
       <md-menu-item>
@@ -84,7 +94,7 @@
       </md-menu-item>
 
       <md-menu-item>
-        <md-button target="_blank" href="https://www.seeedstudio.com/Smart-Citizen-Starter-Kit-p-2865.html">
+        <md-button target="_blank" href="{{vm.seeed_url}}">
           Get your kit
         </md-button>
       </md-menu-item>

--- a/src/app/components/login/login.controller.js
+++ b/src/app/components/login/login.controller.js
@@ -4,10 +4,15 @@
   angular.module('app.components')
     .controller('LoginController', LoginController);
 
-  LoginController.$inject = ['$scope', '$mdDialog'];
-  function LoginController($scope, $mdDialog) {
+  LoginController.$inject = ['$scope', '$window', 'urlUtils', 'URLS'];
+  function LoginController($scope, $window, urlUtils, URLS) {
 
     $scope.showLogin = showLogin;
+
+    var vm = this;
+    vm.ui_base_url = URLS['base']
+    var goto_path = URLS['goto'];
+    vm.login_url = vm.ui_base_url + URLS['login']+ urlUtils.get_path(goto_path, ":url" , $window.location);
 
     $scope.$on('showLogin', function() {
       showLogin();
@@ -25,6 +30,5 @@
         clickOutsideToClose: true
       });
     }
-
   }
 })();

--- a/src/app/components/login/login.html
+++ b/src/app/components/login/login.html
@@ -1,4 +1,4 @@
-<md-button class="md-flat" ng-click="showLogin($event)"
+<md-button class="md-flat" href="{{vm.login_url}}"
   angular-on="click" angular-event="Login" angular-action="click">
   Log In
 </md-button>

--- a/src/app/components/myProfile/Kits.html
+++ b/src/app/components/myProfile/Kits.html
@@ -30,7 +30,7 @@
         </div>
         <!-- KIT LIST -->
         <!-- TODO: Improvement -->
-        <kit-list actions="{remove: vm.removeDevice, downloadData: vm.downloadData}" devices="vm.filteredDevices"></kit-list>
+        <kit-list actions="{downloadData: vm.downloadData}" devices="vm.filteredDevices"></kit-list>
         <!-- End kit list -->
         <div class="kitList kitList_borderBottom" class="kitList_borderBottom" ng-show="!vm.devices.length">
             <div class="kitList_container">

--- a/src/app/components/myProfile/myProfile.controller.js
+++ b/src/app/components/myProfile/myProfile.controller.js
@@ -4,379 +4,395 @@
   angular.module('app.components')
     .controller('MyProfileController', MyProfileController);
 
-    MyProfileController.$inject = ['$scope', '$location', '$q', '$interval',
-    'userData', 'AuthUser', 'user', 'auth', 'alert',
-    'COUNTRY_CODES', '$timeout', 'file', 'animation',
-    '$mdDialog', 'PreviewDevice', 'device', 'deviceUtils',
-    'userUtils', '$filter', '$state', 'Restangular', '$window'];
-    function MyProfileController($scope, $location, $q, $interval,
-      userData, AuthUser, user, auth, alert,
-      COUNTRY_CODES, $timeout, file, animation,
-      $mdDialog, PreviewDevice, device, deviceUtils,
-      userUtils, $filter, $state, Restangular, $window) {
+    MyProfileController.$inject = ['$scope', '$window', '$location',
+    'URLS','userData', 'AuthUser', 'urlUtils', 'user'];
+    function MyProfileController($scope,  $window, $location, URLS, userData, AuthUser, urlUtils, user) {
+
+      var ui_base_url = URLS['base']
+      var users_path = URLS['users:username']
 
       var vm = this;
-
-      vm.unhighlightIcon = unhighlightIcon;
-
-      //PROFILE TAB
-      vm.formUser = {};
-      vm.getCountries = getCountries;
-
       vm.user = userData;
-      copyUserToForm(vm.formUser, vm.user);
-      vm.searchText = vm.formUser.country;
 
-      vm.updateUser = updateUser;
-      vm.removeUser = removeUser;
-      vm.uploadAvatar = uploadAvatar;
-
-      //THIS IS TEMPORARY.
-      // Will grow on to a dynamic API KEY management
-      // with the new /accounts oAuth mgmt methods
-
-      // The auth controller has not populated the `user` at this point,
-      // so  user.token is undefined
-      // This controller depends on auth has already been run.
-      vm.user.token = auth.getToken();
-      vm.addNewDevice = addNewDevice;
-
-      //KITS TAB
-      vm.devices = [];
-      vm.deviceStatus = undefined;
-      vm.removeDevice = removeDevice;
-      vm.downloadData = downloadData;
-
-      vm.filteredDevices = [];
-      vm.dropdownSelected = undefined;
-
-      //SIDEBAR
-      vm.filterDevices = filterDevices;
-      vm.filterTools = filterTools;
-
-      vm.selectThisTab = selectThisTab;
-
-      $scope.$on('loggedOut', function() {
-        $location.path('/');
-      });
-
-      $scope.$on('devicesContextUpdated', function(){
-        var userData = auth.getCurrentUser().data;
-        if(userData){
-          vm.user = userData;
-        }
-        initialize();
-      });
-
-      initialize();
-
-      //////////////////
-
-      function initialize() {
-
-        startingTab();
-        if(!vm.user.devices.length) {
-          vm.devices = [];
-          animation.viewLoaded();
-        } else {
-
-          vm.devices = vm.user.devices.map(function(data) {
-            return new PreviewDevice(data);
-          })
-
-          $timeout(function() {
-            mapWithBelongstoUser(vm.devices);
-            filterDevices(vm.status);
-            setSidebarMinHeight();
-            animation.viewLoaded();
-          });
-
-        }
-      }
-
-      function filterDevices(status) {
-        if(status === 'all') {
-          status = undefined;
-        }
-        vm.deviceStatus = status;
-        vm.filteredDevices = $filter('filterLabel')(vm.devices, vm.deviceStatus);
-      }
-
-      function filterTools(type) {
-        if(type === 'all') {
-          type = undefined;
-        }
-        vm.toolType = type;
-      }
-
-      function updateUser(userData) {
-        if(userData.country) {
-          _.each(COUNTRY_CODES, function(value, key) {
-            if(value === userData.country) {
-              /*jshint camelcase: false */
-              userData.country_code = key;
-              return;
-            }
-          });
-        } else {
-          userData.country_code = null;
-        }
-
-        user.updateUser(userData)
-          .then(function(data) {
-            var user = new AuthUser(data);
-            _.extend(vm.user, user);
-            auth.updateUser();
-            vm.errors = {};
-            alert.success('User updated');
-          })
-          .catch(function(err) {
-            alert.error('User could not be updated ');
-            vm.errors = err.data.errors;
-          });
-      }
-
-      function removeUser() {
-        var confirm = $mdDialog.confirm()
-          .title('Delete your account?')
-          .textContent('Are you sure you want to delete your account?')
-          .ariaLabel('')
-          .ok('delete')
-          .cancel('cancel')
-          .theme('primary')
-          .clickOutsideToClose(true);
-
-        $mdDialog.show(confirm)
-          .then(function(){
-            return Restangular.all('').customDELETE('me')
-              .then(function(){
-                alert.success('Account removed successfully. Redirecting you…');
-                $timeout(function(){
-                  auth.logout();
-                  $state.transitionTo('landing');
-                }, 2000);
-              })
-              .catch(function(){
-                alert.error('Error occurred trying to delete your account.');
-              });
-          });
-      }
-
-      function selectThisTab(iconIndex, uistate){
-        /* This looks more like a hack but we need to workout how to properly use md-tab with ui-router */
-
-        highlightIcon(iconIndex);
-
-        if ($state.current.name.includes('myProfileAdmin')){
-            var transitionState = 'layout.myProfileAdmin.' + uistate;
-            $state.transitionTo(transitionState, {id: userData.id});
-        } else {
-            var transitionState = 'layout.myProfile.' + uistate;
-            $state.transitionTo(transitionState);
-        }
-
-      }
-
-      function startingTab() {
-        /* This looks more like a hack but we need to workout how to properly use md-tab with ui-router */
-
-        var childState = $state.current.name.split('.').pop();
-
-        switch(childState) {
-          case 'user':
-            vm.startingTab = 1;
-            break;
-          default:
-            vm.startingTab = 0;
-            break;
-        }
-
-      }
-
-      function highlightIcon(iconIndex) {
-
-        var icons = angular.element('.myProfile_tab_icon');
-
-        _.each(icons, function(icon) {
-          unhighlightIcon(icon);
-        });
-
-        var icon = icons[iconIndex];
-
-        angular.element(icon).find('.stroke_container').css({'stroke': 'white', 'stroke-width': '0.01px'});
-        angular.element(icon).find('.fill_container').css('fill', 'white');
-      }
-
-      function unhighlightIcon(icon) {
-        icon = angular.element(icon);
-
-        icon.find('.stroke_container').css({'stroke': 'none'});
-        icon.find('.fill_container').css('fill', '#FF8600');
-      }
-
-      function setSidebarMinHeight() {
-        var height = document.body.clientHeight / 4 * 3;
-        angular.element('.profile_content').css('min-height', height + 'px');
-      }
-
-      function getCountries(searchText) {
-        return _.filter(COUNTRY_CODES, createFilter(searchText));
-      }
-
-      function createFilter(searchText) {
-        searchText = searchText.toLowerCase();
-        return function(country) {
-          country = country.toLowerCase();
-          return country.indexOf(searchText) !== -1;
-        };
-      }
-
-      function uploadAvatar(fileData) {
-        if(fileData && fileData.length) {
-
-          // TODO: Improvement Is there a simpler way to patch the image to the API and use the response?
-          // Something like:
-          //Restangular.all('/me').patch(data);
-          // Instead of doing it manually like here:
-          var fd = new FormData();
-          fd.append('profile_picture', fileData[0]);
-          Restangular.one('/me')
-            .withHttpConfig({transformRequest: angular.identity})
-            .customPATCH(fd, '', undefined, {'Content-Type': undefined})
-            .then(function(resp){
-              vm.user.profile_picture = resp.profile_picture;
-            })
-        }
-      }
-
-      function copyUserToForm(formData, userData) {
-        var props = {username: true, email: true, city: true, country: true, country_code: true, url: true, constructor: false};
-
-        for(var key in userData) {
-          if(props[key]) {
-            formData[key] = userData[key];
-          }
-        }
-      }
-
-      function mapWithBelongstoUser(devices){
-        _.map(devices, addBelongProperty);
-      }
-
-      function addBelongProperty(device){
-        device.belongProperty = deviceBelongsToUser(device);
-        return device;
-      }
-
-
-      function deviceBelongsToUser(device){
-        if(!auth.isAuth() || !device || !device.id) {
-          return false;
-        }
-        var deviceID = parseInt(device.id);
-        var userData = ( auth.getCurrentUser().data ) ||
-          ($window.localStorage.getItem('smartcitizen.data') &&
-          new AuthUser( JSON.parse(
-            $window.localStorage.getItem('smartcitizen.data') )));
-
-        var belongsToUser = deviceUtils.belongsToUser(userData.devices, deviceID);
-        var isAdmin = userUtils.isAdmin(userData);
-
-        return isAdmin || belongsToUser;
-      }
-
-      function downloadData(device){
-        $mdDialog.show({
-          hasBackdrop: true,
-          controller: 'DownloadModalController',
-          controllerAs: 'vm',
-          templateUrl: 'app/components/download/downloadModal.html',
-          clickOutsideToClose: true,
-          locals: {thisDevice:device}
-        }).then(function(){
-          var alert = $mdDialog.alert()
-          .title('SUCCESS')
-          .textContent('We are processing your data. Soon you will be notified in your inbox')
-          .ariaLabel('')
-          .ok('OK!')
-          .theme('primary')
-          .clickOutsideToClose(true);
-
-          $mdDialog.show(alert);
-        }).catch(function(err){
-          if (!err){
-            return;
-          }
-          var errorAlert = $mdDialog.alert()
-          .title('ERROR')
-          .textContent('Uh-oh, something went wrong')
-          .ariaLabel('')
-          .ok('D\'oh')
-          .theme('primary')
-          .clickOutsideToClose(false);
-
-          $mdDialog.show(errorAlert);
-        });
-      }
-
-      function removeDevice(deviceID) {
-        var confirm = $mdDialog.confirm()
-          .title('Delete this kit?')
-          .textContent('Are you sure you want to delete this kit?')
-          .ariaLabel('')
-          .ok('DELETE')
-          .cancel('Cancel')
-          .theme('primary')
-          .clickOutsideToClose(true);
-
-        $mdDialog
-          .show(confirm)
-          .then(function(){
-            device
-              .removeDevice(deviceID)
-              .then(function(){
-                alert.success('Your kit was deleted successfully');
-                device.updateContext();
-              })
-              .catch(function(){
-                alert.error('Error trying to delete your kit.');
-              });
-          });
-      }
-
-      $scope.addDeviceSelector = addDeviceSelector;
-      function addDeviceSelector(){
-        $mdDialog.show({
-          templateUrl: 'app/components/myProfile/addDeviceSelectorModal.html',
-          clickOutsideToClose: true,
-          multiple: true,
-          controller: DialogController,
-        });
-      }
-
-      function DialogController($scope, $mdDialog){
-        $scope.cancel = function(){
-          $mdDialog.cancel();
-        };
-      }
-
-      function addNewDevice() {
-        var confirm = $mdDialog.confirm()
-          .title('Hey! Do you want to add a new kit?')
-          .textContent('Please, notice this currently supports just the SCK 1.0 and SCK 1.1')
-          .ariaLabel('')
-          .ok('Ok')
-          .cancel('Cancel')
-          .theme('primary')
-          .clickOutsideToClose(true);
-
-        $mdDialog
-          .show(confirm)
-          .then(function(){
-           $state.go('layout.kitAdd');
-          });
-      }
-
-
+      $window.location.href = ui_base_url + urlUtils.get_path(users_path, ":username" , vm.user.username);
     }
+
+  // angular.module('app.components')
+  //   .controller('MyProfileController', MyProfileController);
+
+  //   MyProfileController.$inject = ['$scope', '$location', '$q', '$interval',
+  //   'userData', 'AuthUser', 'user', 'auth', 'alert',
+  //   'COUNTRY_CODES', '$timeout', 'file', 'animation',
+  //   '$mdDialog', 'PreviewDevice', 'device', 'deviceUtils',
+  //   'userUtils', '$filter', '$state', 'Restangular', '$window'];
+  //   function MyProfileController($scope, $location, $q, $interval,
+  //     userData, AuthUser, user, auth, alert,
+  //     COUNTRY_CODES, $timeout, file, animation,
+  //     $mdDialog, PreviewDevice, device, deviceUtils,
+  //     userUtils, $filter, $state, Restangular, $window) {
+
+  //     var vm = this;
+
+  //     vm.unhighlightIcon = unhighlightIcon;
+
+  //     //PROFILE TAB
+  //     vm.formUser = {};
+  //     vm.getCountries = getCountries;
+
+  //     vm.user = userData;
+  //     copyUserToForm(vm.formUser, vm.user);
+  //     vm.searchText = vm.formUser.country;
+
+  //     vm.updateUser = updateUser;
+  //     vm.removeUser = removeUser;
+  //     vm.uploadAvatar = uploadAvatar;
+
+  //     //THIS IS TEMPORARY.
+  //     // Will grow on to a dynamic API KEY management
+  //     // with the new /accounts oAuth mgmt methods
+
+  //     // The auth controller has not populated the `user` at this point,
+  //     // so  user.token is undefined
+  //     // This controller depends on auth has already been run.
+  //     vm.user.token = auth.getToken();
+  //     vm.addNewDevice = addNewDevice;
+
+  //     //KITS TAB
+  //     vm.devices = [];
+  //     vm.deviceStatus = undefined;
+  //     vm.removeDevice = removeDevice;
+  //     vm.downloadData = downloadData;
+
+  //     vm.filteredDevices = [];
+  //     vm.dropdownSelected = undefined;
+
+  //     //SIDEBAR
+  //     vm.filterDevices = filterDevices;
+  //     vm.filterTools = filterTools;
+
+  //     vm.selectThisTab = selectThisTab;
+
+  //     $scope.$on('loggedOut', function() {
+  //       $location.path('/');
+  //     });
+
+  //     $scope.$on('devicesContextUpdated', function(){
+  //       var userData = auth.getCurrentUser().data;
+  //       if(userData){
+  //         vm.user = userData;
+  //       }
+  //       initialize();
+  //     });
+
+  //     initialize();
+
+  //     //////////////////
+
+  //     function initialize() {
+
+  //       startingTab();
+  //       if(!vm.user.devices.length) {
+  //         vm.devices = [];
+  //         animation.viewLoaded();
+  //       } else {
+
+  //         vm.devices = vm.user.devices.map(function(data) {
+  //           return new PreviewDevice(data);
+  //         })
+
+  //         $timeout(function() {
+  //           mapWithBelongstoUser(vm.devices);
+  //           filterDevices(vm.status);
+  //           setSidebarMinHeight();
+  //           animation.viewLoaded();
+  //         });
+
+  //       }
+  //     }
+
+  //     function filterDevices(status) {
+  //       if(status === 'all') {
+  //         status = undefined;
+  //       }
+  //       vm.deviceStatus = status;
+  //       vm.filteredDevices = $filter('filterLabel')(vm.devices, vm.deviceStatus);
+  //     }
+
+  //     function filterTools(type) {
+  //       if(type === 'all') {
+  //         type = undefined;
+  //       }
+  //       vm.toolType = type;
+  //     }
+
+  //     function updateUser(userData) {
+  //       if(userData.country) {
+  //         _.each(COUNTRY_CODES, function(value, key) {
+  //           if(value === userData.country) {
+  //             /*jshint camelcase: false */
+  //             userData.country_code = key;
+  //             return;
+  //           }
+  //         });
+  //       } else {
+  //         userData.country_code = null;
+  //       }
+
+  //       user.updateUser(userData)
+  //         .then(function(data) {
+  //           var user = new AuthUser(data);
+  //           _.extend(vm.user, user);
+  //           auth.updateUser();
+  //           vm.errors = {};
+  //           alert.success('User updated');
+  //         })
+  //         .catch(function(err) {
+  //           alert.error('User could not be updated ');
+  //           vm.errors = err.data.errors;
+  //         });
+  //     }
+
+  //     function removeUser() {
+  //       var confirm = $mdDialog.confirm()
+  //         .title('Delete your account?')
+  //         .textContent('Are you sure you want to delete your account?')
+  //         .ariaLabel('')
+  //         .ok('delete')
+  //         .cancel('cancel')
+  //         .theme('primary')
+  //         .clickOutsideToClose(true);
+
+  //       $mdDialog.show(confirm)
+  //         .then(function(){
+  //           return Restangular.all('').customDELETE('me')
+  //             .then(function(){
+  //               alert.success('Account removed successfully. Redirecting you…');
+  //               $timeout(function(){
+  //                 auth.logout();
+  //                 $state.transitionTo('landing');
+  //               }, 2000);
+  //             })
+  //             .catch(function(){
+  //               alert.error('Error occurred trying to delete your account.');
+  //             });
+  //         });
+  //     }
+
+  //     function selectThisTab(iconIndex, uistate){
+  //       /* This looks more like a hack but we need to workout how to properly use md-tab with ui-router */
+
+  //       highlightIcon(iconIndex);
+
+  //       if ($state.current.name.includes('myProfileAdmin')){
+  //           var transitionState = 'layout.myProfileAdmin.' + uistate;
+  //           $state.transitionTo(transitionState, {id: userData.id});
+  //       } else {
+  //           var transitionState = 'layout.myProfile.' + uistate;
+  //           $state.transitionTo(transitionState);
+  //       }
+
+  //     }
+
+  //     function startingTab() {
+  //       /* This looks more like a hack but we need to workout how to properly use md-tab with ui-router */
+
+  //       var childState = $state.current.name.split('.').pop();
+
+  //       switch(childState) {
+  //         case 'user':
+  //           vm.startingTab = 1;
+  //           break;
+  //         default:
+  //           vm.startingTab = 0;
+  //           break;
+  //       }
+
+  //     }
+
+  //     function highlightIcon(iconIndex) {
+
+  //       var icons = angular.element('.myProfile_tab_icon');
+
+  //       _.each(icons, function(icon) {
+  //         unhighlightIcon(icon);
+  //       });
+
+  //       var icon = icons[iconIndex];
+
+  //       angular.element(icon).find('.stroke_container').css({'stroke': 'white', 'stroke-width': '0.01px'});
+  //       angular.element(icon).find('.fill_container').css('fill', 'white');
+  //     }
+
+  //     function unhighlightIcon(icon) {
+  //       icon = angular.element(icon);
+
+  //       icon.find('.stroke_container').css({'stroke': 'none'});
+  //       icon.find('.fill_container').css('fill', '#FF8600');
+  //     }
+
+  //     function setSidebarMinHeight() {
+  //       var height = document.body.clientHeight / 4 * 3;
+  //       angular.element('.profile_content').css('min-height', height + 'px');
+  //     }
+
+  //     function getCountries(searchText) {
+  //       return _.filter(COUNTRY_CODES, createFilter(searchText));
+  //     }
+
+  //     function createFilter(searchText) {
+  //       searchText = searchText.toLowerCase();
+  //       return function(country) {
+  //         country = country.toLowerCase();
+  //         return country.indexOf(searchText) !== -1;
+  //       };
+  //     }
+
+  //     function uploadAvatar(fileData) {
+  //       if(fileData && fileData.length) {
+
+  //         // TODO: Improvement Is there a simpler way to patch the image to the API and use the response?
+  //         // Something like:
+  //         //Restangular.all('/me').patch(data);
+  //         // Instead of doing it manually like here:
+  //         var fd = new FormData();
+  //         fd.append('profile_picture', fileData[0]);
+  //         Restangular.one('/me')
+  //           .withHttpConfig({transformRequest: angular.identity})
+  //           .customPATCH(fd, '', undefined, {'Content-Type': undefined})
+  //           .then(function(resp){
+  //             vm.user.profile_picture = resp.profile_picture;
+  //           })
+  //       }
+  //     }
+
+  //     function copyUserToForm(formData, userData) {
+  //       var props = {username: true, email: true, city: true, country: true, country_code: true, url: true, constructor: false};
+
+  //       for(var key in userData) {
+  //         if(props[key]) {
+  //           formData[key] = userData[key];
+  //         }
+  //       }
+  //     }
+
+  //     function mapWithBelongstoUser(devices){
+  //       _.map(devices, addBelongProperty);
+  //     }
+
+  //     function addBelongProperty(device){
+  //       device.belongProperty = deviceBelongsToUser(device);
+  //       return device;
+  //     }
+
+
+  //     function deviceBelongsToUser(device){
+  //       if(!auth.isAuth() || !device || !device.id) {
+  //         return false;
+  //       }
+  //       var deviceID = parseInt(device.id);
+  //       var userData = ( auth.getCurrentUser().data ) ||
+  //         ($window.localStorage.getItem('smartcitizen.data') &&
+  //         new AuthUser( JSON.parse(
+  //           $window.localStorage.getItem('smartcitizen.data') )));
+
+  //       var belongsToUser = deviceUtils.belongsToUser(userData.devices, deviceID);
+  //       var isAdmin = userUtils.isAdmin(userData);
+
+  //       return isAdmin || belongsToUser;
+  //     }
+
+  //     function downloadData(device){
+  //       $mdDialog.show({
+  //         hasBackdrop: true,
+  //         controller: 'DownloadModalController',
+  //         controllerAs: 'vm',
+  //         templateUrl: 'app/components/download/downloadModal.html',
+  //         clickOutsideToClose: true,
+  //         locals: {thisDevice:device}
+  //       }).then(function(){
+  //         var alert = $mdDialog.alert()
+  //         .title('SUCCESS')
+  //         .textContent('We are processing your data. Soon you will be notified in your inbox')
+  //         .ariaLabel('')
+  //         .ok('OK!')
+  //         .theme('primary')
+  //         .clickOutsideToClose(true);
+
+  //         $mdDialog.show(alert);
+  //       }).catch(function(err){
+  //         if (!err){
+  //           return;
+  //         }
+  //         var errorAlert = $mdDialog.alert()
+  //         .title('ERROR')
+  //         .textContent('Uh-oh, something went wrong')
+  //         .ariaLabel('')
+  //         .ok('D\'oh')
+  //         .theme('primary')
+  //         .clickOutsideToClose(false);
+
+  //         $mdDialog.show(errorAlert);
+  //       });
+  //     }
+
+  //     function removeDevice(deviceID) {
+  //       var confirm = $mdDialog.confirm()
+  //         .title('Delete this kit?')
+  //         .textContent('Are you sure you want to delete this kit?')
+  //         .ariaLabel('')
+  //         .ok('DELETE')
+  //         .cancel('Cancel')
+  //         .theme('primary')
+  //         .clickOutsideToClose(true);
+
+  //       $mdDialog
+  //         .show(confirm)
+  //         .then(function(){
+  //           device
+  //             .removeDevice(deviceID)
+  //             .then(function(){
+  //               alert.success('Your kit was deleted successfully');
+  //               device.updateContext();
+  //             })
+  //             .catch(function(){
+  //               alert.error('Error trying to delete your kit.');
+  //             });
+  //         });
+  //     }
+
+  //     $scope.addDeviceSelector = addDeviceSelector;
+  //     function addDeviceSelector(){
+  //       $mdDialog.show({
+  //         templateUrl: 'app/components/myProfile/addDeviceSelectorModal.html',
+  //         clickOutsideToClose: true,
+  //         multiple: true,
+  //         controller: DialogController,
+  //       });
+  //     }
+
+  //     function DialogController($scope, $mdDialog){
+  //       $scope.cancel = function(){
+  //         $mdDialog.cancel();
+  //       };
+  //     }
+
+  //     function addNewDevice() {
+  //       var confirm = $mdDialog.confirm()
+  //         .title('Hey! Do you want to add a new kit?')
+  //         .textContent('Please, notice this currently supports just the SCK 1.0 and SCK 1.1')
+  //         .ariaLabel('')
+  //         .ok('Ok')
+  //         .cancel('Cancel')
+  //         .theme('primary')
+  //         .clickOutsideToClose(true);
+
+  //       $mdDialog
+  //         .show(confirm)
+  //         .then(function(){
+  //          $state.go('layout.kitAdd');
+  //         });
+  //     }
+
+
+  //   }
 })();

--- a/src/app/components/myProfile/myProfile.html
+++ b/src/app/components/myProfile/myProfile.html
@@ -1,4 +1,7 @@
-<section class="myProfile_state" layout="column">
+
+<!-- TODO Add interstitial? -->
+
+<!-- <section class="myProfile_state" layout="column">
   <div class="profile_header myProfile_header dark">
     <div class="myProfile_header_container" layout="row">
       <img ng-src="{{ vm.user.profile_picture || './assets/images/avatar.svg' }}" class="profile_header_avatar myProfile_header_avatar" />
@@ -44,4 +47,4 @@
       </md-tab>
     </md-tabs>
   </div>
-</section>
+</section> -->

--- a/src/app/components/store/store.controller.js
+++ b/src/app/components/store/store.controller.js
@@ -4,15 +4,17 @@
   angular.module('app.components')
     .controller('StoreController', StoreController);
 
-  StoreController.$inject = ['$scope', '$mdDialog'];
-  function StoreController($scope, $mdDialog) {
+  StoreController.$inject = ['$scope', '$mdDialog', 'URLS'];
+  function StoreController($scope, $mdDialog, URLS) {
 
     $scope.showStore = showStore;
+    var vm = this;
+    vm.seeed = URLS['seeed'];
 
     $scope.$on('showStore', function() {
       showStore();
     });
-    
+
     ////////////////
 
     function showStore() {

--- a/src/app/components/store/store.html
+++ b/src/app/components/store/store.html
@@ -1,6 +1,6 @@
 <md-button class="md-flat"
   ng-class="(isLoggedin) ? 'navbar_highlight_button' : 'no-class'"
-  ng-href="https://www.seeedstudio.com/Smart-Citizen-Starter-Kit-p-2865.html">
+  ng-href="{{vm.seeed}}">
   <md-tooltip md-direction="bottom">Get your kit on Seeed studio</md-tooltip>
   Get your Kit
 </md-button>

--- a/src/app/components/upload/csvUpload.component.js
+++ b/src/app/components/upload/csvUpload.component.js
@@ -34,8 +34,6 @@ function parseDataForPost(csvArray) {
   };
 }
 
-
-
 controller.$inject = ['device', 'Papa', '$mdDialog', '$q'];
 function controller(device, Papa, $mdDialog, $q) {
   var vm = this;

--- a/src/app/components/upload/upload.controller.js
+++ b/src/app/components/upload/upload.controller.js
@@ -4,28 +4,46 @@
   angular.module('app.components')
     .controller('UploadController', UploadController);
 
-  UploadController.$inject = ['kit', '$state', '$stateParams', 'animation'];
-  function UploadController(kit, $state, $stateParams, animation) {
-    var vm = this;
+    UploadController.$inject = ['kit', '$scope', '$window', '$location', '$stateParams', 'URLS', 'AuthUser', 'urlUtils', 'user'];
+    function UploadController(kit, $scope,  $window, $location, $stateParams, URLS, AuthUser, urlUtils, user) {
 
-    vm.kit = kit;
+      var ui_base_url = URLS['base'];
+      var device_upload_path = URLS['devices:id:upload'];
 
-    vm.backToProfile = backToProfile;
+      var vm = this;
+      vm.kit = kit;
+      console.log(vm.kit)
 
-    initialize();
+      vm.device_id = vm.kit.id;
 
-    /////////////////
-
-    function initialize() {
-      animation.viewLoaded();
+      $window.location.href = ui_base_url + urlUtils.get_path(device_upload_path, ":id" , vm.device_id);
     }
 
-    function backToProfile() {
-      $state.transitionTo('layout.myProfile.kits', $stateParams,
-      { reload: false,
-        inherit: false,
-        notify: true
-      });
-    }
-  }
+  // angular.module('app.components')
+  //   .controller('UploadController', UploadController);
+
+  // UploadController.$inject = ['kit', '$state', '$stateParams', 'animation'];
+  // function UploadController(kit, $state, $stateParams, animation) {
+  //   var vm = this;
+
+  //   vm.kit = kit;
+
+  //   vm.backToProfile = backToProfile;
+
+  //   initialize();
+
+  //   /////////////////
+
+  //   function initialize() {
+  //     animation.viewLoaded();
+  //   }
+
+  //   function backToProfile() {
+  //     $state.transitionTo('layout.myProfile.kits', $stateParams,
+  //     { reload: false,
+  //       inherit: false,
+  //       notify: true
+  //     });
+  //   }
+  // }
 })();

--- a/src/app/components/upload/upload.html
+++ b/src/app/components/upload/upload.html
@@ -1,9 +1,8 @@
 <!-- <section class="kit_dataChange"> -->
-<section class="upload-csv timeline" flex="1" layout="row" layout-align="center center">
+<!-- <section class="upload-csv timeline" flex="1" layout="row" layout-align="center center">
   <div class="container" layout="row" layout-align="space-between center">
       <span class="timeline-title">CSV File Upload</span>
       <md-button style="margin-left: auto" class="timeline_buttonBack btn-round-new btn-outline-white" ui-sref="layout.home.kit({id: vm.kit.id})" >Back to Kit</md-button>
-<!-- 	  <md-button style="margin-left: auto" class="md-flat md-primary timeline_buttonBack" ng-click="vm.backToProfile()">Back to Profile</md-button> -->
     </div>
   </div>
 </section>
@@ -11,4 +10,4 @@
   <div class="container csv_content">
     <sc-csv-upload kit="vm.kit"><sc-csv-upload>
   </div>
-</section>
+</section> -->

--- a/src/app/core/api/device.service.js
+++ b/src/app/core/api/device.service.js
@@ -20,8 +20,8 @@
         setWorldMarkers: setWorldMarkers,
         mailReadings: mailReadings,
         postReadings: postReadings,
-				removeDevice: removeDevice,
-        updateContext: updateContext
+				// removeDevice: removeDevice,
+        // updateContext: updateContext
 	  	};
 
 	  	return service;
@@ -121,21 +121,21 @@
           .post('readings', readings);
 			}
 
-			function removeDevice(deviceID){
-				return Restangular
-          .one('devices', deviceID)
-					.remove().then(function () {
-            $rootScope.$broadcast('devicesContextUpdated');
-          })
-        ;
-			}
+			// function removeDevice(deviceID){
+			// 	return Restangular
+      //     .one('devices', deviceID)
+			// 		.remove().then(function () {
+      //       $rootScope.$broadcast('devicesContextUpdated');
+      //     })
+      //   ;
+			// }
 
-      function updateContext (){
-        return auth.updateUser().then(function(){
-          removeMarkers();
-          $rootScope.$broadcast('devicesContextUpdated');
-        });
-      }
+      // function updateContext (){
+      //   return auth.updateUser().then(function(){
+      //     removeMarkers();
+      //     $rootScope.$broadcast('devicesContextUpdated');
+      //   });
+      // }
 
 	  }
 })();

--- a/src/app/core/constants/dropdownOptionsCommunity.constant.js
+++ b/src/app/core/constants/dropdownOptionsCommunity.constant.js
@@ -13,7 +13,7 @@
       {text: 'Forum', href: 'https://forum.smartcitizen.me/'},
       {text: 'Documentation', href: 'http://docs.smartcitizen.me/'},
       {text: 'API Reference', href: 'http://developer.smartcitizen.me/'},
-      {text: 'Github', href: 'https://github.com/fablabbcn/Smart-Citizen-Kit'},
+      {text: 'Github', href: 'https://github.com/fablabbcn/smartcitizen-kit-2x'},
       {text: 'Legal', href: '/policy'}
     ]);
 })();

--- a/src/app/core/constants/dropdownOptionsUser.constant.js
+++ b/src/app/core/constants/dropdownOptionsUser.constant.js
@@ -6,10 +6,9 @@
    * @constant
    * @type {Array}
    */
-  angular.module('app.components')
-    .constant('DROPDOWN_OPTIONS_USER', [
-      {divider: true, text: 'Hi,', href: './profile'},
-      {text: 'My profile', href: './profile'},
-      {text: 'Log out', href: './logout'}
-    ]);
+  // angular.module('app.components')
+  //   .constant('DROPDOWN_OPTIONS_USER', [
+  //     {divider: true, text: 'Hi,', href: './profile', onclick: ''},
+  //     {text: 'My profile', href: './profile'}
+  //   ]);
 })();

--- a/src/app/core/constants/uiUrls.constant.js
+++ b/src/app/core/constants/uiUrls.constant.js
@@ -1,0 +1,26 @@
+(function() {
+    'use strict';
+
+    /**
+     * Country codes.
+     * @constant
+     * @type {Object}
+     */
+
+    angular.module('app.components')
+      .constant('URLS', {
+        // TODO Change
+        'base': 'https://api.smartcitizen.me/ui',
+        'seeed': 'https://www.seeedstudio.com/Smart-Citizen2-3-p-6327.html',
+        'login': '/sessions/new',
+        'logout': '/sessions/destroy',
+        'users': '/users',
+        'newUsers': '/users/new',
+        'users:username': '/users/:username',
+        'devices:id:edit': '/devices/:id/edit',
+        'devices:id:download': '/devices/:id/download',
+        'devices:id:upload': '/devices/:id/upload',
+        'devices:id:delete': '/devices/:id/delete',
+        'goto': '?goto=:url'
+    });
+  })();

--- a/src/app/core/utils/urlUtils.service.js
+++ b/src/app/core/utils/urlUtils.service.js
@@ -1,0 +1,24 @@
+(function() {
+    'use strict';
+
+    angular.module('app.components')
+      .factory('urlUtils', urlUtils);
+
+      function urlUtils() {
+        var service = {
+          get_path: get_path
+        };
+        return service;
+
+        ///////////
+
+        function get_path(url, placeholder, input) {
+            return url.replace(placeholder, input);
+        }
+
+      }
+  })();
+
+
+
+


### PR DESCRIPTION
This PR integrates with the monolith by @timcowlishaw.

The only view left is the map, together with the landing. 

The following operations are now passed on to the monolith:

- [x] Log in (with goto parameter to return back to map/kit page)
- [ ] Sign up
- [x] My profile
- [x] Profile
- [x] Visit user profile
- [x] Edit button
- [x] Download CSV
- [x] SD Card Upload
- [x] Delete (removed from buttons)
- [x] Log out

All the pages that could be stored somewhere (edit, profile, users) have a redirect to the monolith as well. 

### Solving auth spaghetti

In the current app (master) there is an spaghetti in the auth side. There is a bunch of places that request auth data (via stored token) before we actually check if the user is logged in. I fixed this by completely removing the use of localstorage/cookies for auth purposes, and I rely on the request to '/me' resolving. This presents an issue with CORS, that @timcowlishaw has resolved by whitelisting auth requests from our domain. In principle, it's fine, simplifies everything quite nicely (I think) but it'll require quite some testing before deploying.

### Pending

Beyond the list above:

- [ ] Cleanup code
- [ ] Solve unhandled error when '/me' returns 401
- [ ] Fix urls to the final /ui path
- [ ] Tweaking on styling to make it match with monolith
- [ ] Testing

### Discussion

Now we should discuss whether or not this makes sense or not. Besides the minor issue with CORS, which seems fine, there is a potential issue in that we are touching integral parts of the web, and that it probably makes more sense to transition the map over to the monolith. I think this PR could be there, but I believe that with a bit more of work, we could potentially deprecate this app, and move it all to a more stable stack.

Please, take a look and test, and provide feedback on the different points from above.